### PR TITLE
Added cmb_post_meta_box and CMB_Meta_Boxes abstraction beginnings...

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -195,7 +195,7 @@ abstract class CMB_Field {
 	 * @todo this surely only works for posts
 	 * @todo why do values need to be passed in, they can already be passed in on construct
 	 */
-	public function save( $post_id, $values ) {
+	public function save( $object_id, $values ) {
 
 		$this->values = $values;
 		$this->parse_save_values();
@@ -203,17 +203,17 @@ abstract class CMB_Field {
 		// Allow override from args
 		if ( ! empty( $this->args['save_callback'] ) ) {
 
-			call_user_func( $this->args['save_callback'], $this->values, $post_id );
+			call_user_func( $this->args['save_callback'], $this->values, $object_id );
 
 			return;
 
 		}
 
 		// If we are not on a post edit screen
-		if ( ! $post_id )
+		if ( ! $object_id )
 			return;
 
-		delete_post_meta( $post_id, $this->id );
+		delete_post_meta( $object_id, $this->id );
 
 		foreach( $this->values as $v ) {
 
@@ -221,7 +221,7 @@ abstract class CMB_Field {
 			$this->parse_save_value();
 
 			if ( $this->value || $this->value === '0' )
-				add_post_meta( $post_id, $this->id, $this->value );
+				add_post_meta( $object_id, $this->id, $this->value );
 
 		}
 	}


### PR DESCRIPTION
This pull request aimes to provide a better API for adding meta boxes and also works towards abstracting cmb to support all meta data object types.

This means removing any post specific logic from `CMB_Meta_Box` into `CMB_Post_Meta_Boxes`, with `CMB_Meta_Box` having a type `post|term|etc...` to handle the `get_metadata` calls.

We should probably decide if `CMB_Field` should still be responsible for doing `add_post_meta` (or `add_metadata`) it's self, and if so, why not init the field with an object ID so it can also call `get_metadata` internally. Either geting / saving data should be handled all internally, or not at all - currently we have both.
