### PR TITLE
Constrain uploaded images in the current-image container

### DIFF
--- a/css/plupload-image.css
+++ b/css/plupload-image.css
@@ -6,7 +6,7 @@
 .hm-uploader.with-image .rwmb-drag-drop { display: none }
 
 .hm-uploader .current-image { text-align: center;  position: absolute; background: transparent; top: 0; left: 0; z-index: 3; border: 1px solid #ccc; }
-.hm-uploader .current-image img { display: inline; vertical-align: middle; }
+.hm-uploader .current-image img { display: inline; vertical-align: middle; max-width: 100%; max-height: 100%; }
 
 .hm-uploader .current-image .image-options { position: absolute; bottom: 10px; right: 2px; background: transparent; color: #fff; height: 20px; line-height: 20px; padding: 0 5px; }
 .hidden { display: none; }
@@ -14,7 +14,7 @@
 div.loading-block {
 	text-align: center;
 	line-height: 180px;
-	border-image: initial;	
+	border-image: initial;
 	position: absolute;
 	top: 0; left: 0;
     background: transparent;
@@ -26,7 +26,7 @@ div.loading-block {
 div.rwmb-drag-drop {
     background: transparent;
     border: 4px dashed #DDD;
-	border-image: initial;	
+	border-image: initial;
 	position: absolute;
 	top: 0; left: 0;
 	z-index: 1
@@ -60,5 +60,5 @@ div.rwmb-drag-drop-inside p {
 .rwmb-images div a{
 	position: relative;
 	color: #fff;
-	font-weight: bold; 	
+	font-weight: bold;
 }


### PR DESCRIPTION
i've added max-width: 100% and min-width: 100% to the img inside the .current-image container. this prevents them from overflowing that container after you upload an image.
