### PR TITLE
12-Hour Time Formating Fix

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -680,7 +680,7 @@ class CMB_Datetime_Timestamp_Field extends CMB_Field {
 	public function html() { ?>		
 
 		<input <?php $this->id_attr('date'); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_small cmb_datepicker' ); ?> type="text" <?php $this->name_attr( '[date]' ); ?>  value="<?php echo $this->value ? esc_attr( date( 'm\/d\/Y', $this->value ) ) : '' ?>" />
-		<input <?php $this->id_attr('time'); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_small cmb_timepicker' ); ?> type="text" <?php $this->name_attr( '[time]' ); ?> value="<?php echo $this->value ? esc_attr( date( 'H:i A', $this->value ) ) : '' ?>" />
+		<input <?php $this->id_attr('time'); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_small cmb_timepicker' ); ?> type="text" <?php $this->name_attr( '[time]' ); ?> value="<?php echo $this->value ? esc_attr( date( 'h:i A', $this->value ) ) : '' ?>" />
 
 	<?php }
 


### PR DESCRIPTION
Fixed the Time format to 12-hour format because it is followed by Ante meridiem and Post meridian symbols. It caused strange Time format like "20 AM" and caused the field to save to "empty" because of that the next time you updated the post/page.

![20pm](https://f.cloud.github.com/assets/339914/1141204/50da3ada-1caf-11e3-9e53-384cf3e0b6fc.jpeg)

Signed-off-by: Baki Goxhaj banago@gmail.com
