### PR TITLE
Notice: CMB_Field was called with an argument ...

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -55,9 +55,8 @@ abstract class CMB_Field {
 
 			$re_format = array();
 
-			foreach ( $this->args['options'] as $option ) {
+			foreach ( $this->args['options'] as $option )
 				$re_format[$option['value']] = $option['name'];
-			}
 
 			$this->args['options'] = $re_format;
 		}
@@ -65,7 +64,6 @@ abstract class CMB_Field {
 		// If the field has a custom value populator callback
 		if ( ! empty( $args['values_callback'] ) )
 			$this->values = call_user_func( $args['values_callback'], get_the_id() );
-
 		else
 			$this->values = $values;
 


### PR DESCRIPTION
Here is a PHP notice to be fixed:

> Notice: CMB_Field was called with an argument that is deprecated since version 'std' is deprecated, use 'default instead'! 0.9
