### PR TITLE
add check if CMB_PATH and CMB_URL are already defined

### DIFF
--- a/custom-meta-boxes.php
+++ b/custom-meta-boxes.php
@@ -35,8 +35,11 @@ Version: 	1.0 - Beta 1
  * This may need to be filtered for local Window installations.
  * If resources do not load, please check the wiki for details.
  */
-define( 'CMB_PATH', str_replace( '\\', '/', dirname( __FILE__ ) ) );
-define( 'CMB_URL', str_replace( str_replace( '\\', '/', WP_CONTENT_DIR ), str_replace( '\\', '/', WP_CONTENT_URL ), CMB_PATH ) );
+if( !defined( 'CMB_PATH') )
+	define( 'CMB_PATH', str_replace( '\\', '/', dirname( __FILE__ ) ) );
+if( !defined( 'CMB_URL' ) )
+	define( 'CMB_URL', str_replace( str_replace( '\\', '/', WP_CONTENT_DIR ), str_replace( '\\', '/', WP_CONTENT_URL ), CMB_PATH ) );
+
 
 include_once( CMB_PATH . '/classes.fields.php' );
 include_once( CMB_PATH . '/class.cmb-meta-box.php' );


### PR DESCRIPTION
allows the user to simply include a custom value in their functions.php in case it is being included in a symlinked directory, e.g. (in fuctions.php before require_once call):
define( 'CMB_URL' , get_template_directory_uri() . '/library/Custom-Meta-Boxes/' );

this example returns the correct URI instead of something like http://base.uri/system/path/to/symlinked/folder/, which occurs when the system path to the wp_content_dir is different from the system path to the symlinked, e.g., theme folder.
