### PR TITLE
Propose removal of Oembed field

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -715,65 +715,6 @@ class CMB_Datetime_Timestamp_Field extends CMB_Field {
 
 }
 
-
-/**
- * Standard text meta box for a URL.
- *
- */
-class CMB_Oembed_Field extends CMB_Field {
-
-	public function html() { ?>
-
-		<style>
-
-			.cmb_oembed img, .cmb_oembed object, .cmb_oembed video, .cmb_oembed embed, .cmb_oembed iframe { max-width: 100%; height: auto; }
-
-		</style>
-
-			<?php if ( ! $this->value ) : ?>
-
-				<input class="cmb_oembed code" type="text" <?php $this->name_attr(); ?> id="<?php echo esc_attr( $this->name ); ?>" value="" />
-
-			<?php else : ?>
-
-				<div class="hidden"><input disabled class="cmb_oembed code" type="text" <?php $this->name_attr(); ?> id="<?php echo esc_attr( $this->name ); ?>" value="" /></div>
-
-				<div style="position: relative">
-
-				<?php if ( is_array( $this->value ) ) : ?>
-
-					<span class="cmb_oembed"><?php echo $this->value['object']; ?></span>
-					<input type="hidden" <?php $this->name_attr(); ?> value="<?php echo esc_attr( serialize( $this->value ) ); ?>" />
-
-				<?php else : ?>
-
-					<span class="cmb_oembed"><?php echo $this->value; ?></span>
-					<input type="hidden" <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->value ); ?>" />
-
-				<?php endif; ?>
-
-					<a href="#" class="cmb_remove_file_button" onclick="jQuery( this ).closest('div').prev().removeClass('hidden').find('input').first().removeAttr('disabled')">Remove</a>
-
-				</div>
-
-			<?php endif; ?>
-
-	<?php }
-
-	public function parse_save_value() {
-
-		$args['cmb_oembed'] = true;
-
-		if ( ! empty( $this->args['height'] ) )
-			$args['height'] = $this->args['height'];
-
-		if ( strpos( $this->value, 'http' ) === 0 )
-			$this->value = wp_oembed_get( $this->value, $args );
-
-	}
-
-}
-
 /**
  * Standard text field.
  *

--- a/custom-meta-boxes.php
+++ b/custom-meta-boxes.php
@@ -126,7 +126,6 @@ function _cmb_available_fields() {
 		'checkbox'			=> 'CMB_Checkbox',
 		'file'				=> 'CMB_File_Field',
 		'image' 			=> 'CMB_Image_Field',
-		'oembed'			=> 'CMB_Oembed_Field',
 		'wysiwyg'			=> 'CMB_wysiwyg',
 		'textarea'			=> 'CMB_Textarea_Field',
 		'textarea_code'		=> 'CMB_Textarea_Field_Code',

--- a/example-functions.php
+++ b/example-functions.php
@@ -43,7 +43,6 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		array( 'id' => 'field-21', 'name' => 'Date & Time (unix) input field', 'type' => 'datetime_unix' ),
 		
 		array( 'id' => 'field-22', 'name' => 'Color', 'type' => 'colorpicker' ),
-		array( 'id' => 'field-23', 'name' => 'Oembed field', 'type' => 'oembed' ),
 
 		array( 'id' => 'field-24', 'name' => 'Title Field', 'type' => 'title' ),
 	


### PR DESCRIPTION
First of all... its broken. And nobody has reported a bug for this - so I suspect nobody is using it!

But I'm not sure about the whole concept of this field. WordPress converts oEmbed compatable URL to embed codes on output. But this field does it on save, and stores the full embed code. 

This is much easier if you don't really know what you're doing. But I think it would make more sense to use a text/code field and do the oembedding out output. We could document that this field was removed and provide an example of how to oembed on output.

Would love to know if anyone is actually using this field. If they are, i'm happy to fix it up. Any thoughts @willmot @joehoyle 
