### PR TITLE
Better handling for size args

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -465,22 +465,16 @@ class CMB_Image_Field extends CMB_File_Field {
 			'show_size' => false
 		) );
 
-		// If image size keyword used, convert to array of dimensions.
-		if ( is_string( $args['size'] ) )
-			$args['size'] = $this->get_image_size( $args['size'] );
-
 		if ( $this->get_value() )
 			$image = wp_get_attachment_image_src( $this->get_value(), $args['size'], true );
 
-		$crop = ( isset( $args['size']['crop'] ) && $args['size']['crop'] ) ? 1 : 0;
+		// Convert size arg to array of width, height, crop. 
+		$size = $this->parse_image_size( $args['size'] );
 
-		$styles  = 'width: ' . intval( $args['size'][0] ) . 'px; ';
-		$styles .= 'height: ' . intval( $args['size'][1] ) . 'px; ';
-		$styles .= 'line-height: ' . intval( $args['size'][1] ) . 'px';
-
-		$placeholder_styles  = 'width: ' . ( intval( $args['size'][0] ) - 8 ) . 'px; ';
-		$placeholder_styles .= 'height: ' . ( intval( $args['size'][1] ) - 8 ) . 'px; ';
-
+		// Inline styles.
+		$styles              = sprintf( 'width: %1$dpx; height: %2$dpx; line-height: %2$dpx', intval( $size['width'] ), intval( $size['height'] ) );
+		$placeholder_styles  = sprintf( 'width: %dpx; height: %dpx;', intval( $size['width'] ) - 8, intval( $size['height'] ) - 8 );
+		
 		$data_type = ( ! empty( $args['library-type'] ) ? implode( ',', $args['library-type'] ) : null );
 
 		?>
@@ -491,7 +485,7 @@ class CMB_Image_Field extends CMB_File_Field {
 
 				<?php if ( $this->args['show_size'] ) : ?>
 					<span class="dimensions">
-						<?php printf( '%dpx &times; %dpx', intval( $args['size'][0] ), intval( $args['size'][1] ) ); ?>
+						<?php printf( '%dpx &times; %dpx', intval( $size['width'] ), intval( $size['height'] ) ); ?>
 					</span>
 				<?php endif; ?>
 
@@ -501,7 +495,7 @@ class CMB_Image_Field extends CMB_File_Field {
 				<?php esc_html_e( 'Add Image', 'cmb' ); ?>
 			</button>
 
-			<div class="cmb-file-holder type-img <?php echo $this->get_value() ? '' : 'hidden'; ?>" data-crop="<?php echo (string) $crop; ?>">
+			<div class="cmb-file-holder type-img <?php echo $this->get_value() ? '' : 'hidden'; ?>" data-crop="<?php echo (bool) $size['crop']; ?>">
 
 				<?php if ( ! empty( $image ) ) : ?>
 					<img src="<?php echo esc_url( $image[0] ); ?>" width="<?php echo intval( $image[1] ); ?>" height="<?php echo intval( $image[2] ); ?>" />
@@ -520,31 +514,41 @@ class CMB_Image_Field extends CMB_File_Field {
 	<?php }
 
 	/**
-	 * Gets the dimensions from a registered image size.
-	 *
+	 * Parse the size argument to get pixel width, pixel height and crop information.
+	 * 
 	 * @param  string $size
-	 * @return array dimensions.
+	 * @return array width, height, crop
 	 */
-	private function get_image_size( $size ) {
-
-		if ( in_array( $size, array( 'thumbnail', 'medium', 'large' ) ) ) {
+	private function parse_image_size( $size ) {
+		
+		// Handle string for built-in image sizes
+		if ( is_string( $size ) && in_array( $size, array( 'thumbnail', 'medium', 'large' ) ) ) {
 			return array(
-				get_option( $size . '_size_w' ),
-				get_option( $size . '_size_h' ),
-				'crop' => get_option( $size . '_crop' )
+				'width'  => get_option( $size . '_size_w' ),
+				'height' => get_option( $size . '_size_h' ),
+				'crop'   => get_option( $size . '_crop' )
 			);
 		}
 
+		// Handle string for additional image sizes
 		global $_wp_additional_image_sizes;
-		if ( isset( $_wp_additional_image_sizes[$size] ) ) {
+		if ( is_string( $size ) && isset( $_wp_additional_image_sizes[$size] ) ) {
 			return array(
-				$_wp_additional_image_sizes[$size]['width'],
-				$_wp_additional_image_sizes[$size]['height'],
-				'crop' => $_wp_additional_image_sizes[$size]['crop']
+				'width'  => $_wp_additional_image_sizes[$size]['width'],
+				'height' => $_wp_additional_image_sizes[$size]['height'],
+				'crop'   => $_wp_additional_image_sizes[$size]['crop']
 			);
 		}
 
-		return false;
+		// Handle default WP size format. 
+		if ( is_array( $size ) && isset( $size[0] ) && isset( $size[1] ) )
+			$size = array( 'width' => $size[0], 'height' => $size[0] );
+
+		return wp_parse_args( $size, array(
+			'width'  => get_option( 'thumbnail_size_w' ),
+			'height' => get_option( 'thumbnail_size_h' ),
+			'crop'   => get_option( 'thumbnail_crop' )
+		) );
 
 	}
 


### PR DESCRIPTION
@joe - re [your comment here](https://github.com/humanmade/Custom-Meta-Boxes/pull/81#discussion_r7122139) regarding the mixed up array that was returned... I had a think about how it could be better.

The function should return an array in a saner format which is then used to generate inline styles - and we can just pass the original size arg straight to wp_get_attachment_image so nothing breaks.
