### PR TITLE
Repeatable taxonomy fields are broken

### DIFF
--- a/js/field.select.js
+++ b/js/field.select.js
@@ -26,4 +26,4 @@ var cmbSelectInit = function() {
 CMB.addCallbackForInit( cmbSelectInit );
 CMB.addCallbackForClonedField( 'CMB_Select', cmbSelectInit );
 CMB.addCallbackForClonedField( 'CMB_Post_Select', cmbSelectInit );
-CMB.addCallbackForClonedField( 'CMB_Taxonomy_Select', cmbSelectInit );
+CMB.addCallbackForClonedField( 'CMB_Taxonomy', cmbSelectInit );


### PR DESCRIPTION
Fix - was using the incorrect field class name in the JS
