### PR TITLE
Fields not initialized if meta box is collapsed on page load

### DIFF
--- a/js/cmb.js
+++ b/js/cmb.js
@@ -15,41 +15,32 @@ var CMB = {
 
 	init : function() {
 
-		var _this = this;
-
 		jQuery( '.field.repeatable' ).each( function() {
-			_this.isMaxFields( jQuery(this) );
+			CMB.isMaxFields( jQuery(this) );
 		} );
 
 		// Unbind & Re-bind all CMB events to prevent duplicates.
 		jQuery(document).unbind( 'click.CMB' );
-
-		jQuery( document ).on( 'click.CMB', '.cmb-delete-field', function(e) {
-			e.preventDefault();
-			jQuery(this).blur();
-			_this.deleteField( jQuery( this ).closest('.field-item' ) );
-		} );
-
-		jQuery( document ).on( 'click.CMB', '.repeat-field', function(e) {
-			e.preventDefault();
-			jQuery(this).blur();
-			_this.repeatField( jQuery( this ).closest('.field' ) );
-		} );
+		jQuery(document).on( 'click.CMB', '.cmb-delete-field', CMB.deleteField );
+		jQuery(document).on( 'click.CMB', '.repeat-field', CMB.repeatField );
 
 		// When toggling the display of the meta box container - reinitialize
 		jQuery(document).on( 'click.CMB', '.handlediv', CMB.init )
 
-		_this.doneInit();
+		CMB.doneInit();
 
 	},
 
-	repeatField : function( field ) {
+	repeatField : function( e ) {
 
-	    var _this, templateField, newT, field, index, attr;
+	    var templateField, newT, field, index, attr;
 
-	    _this = this;
+	    field = jQuery( this ).closest('.field' );					
 
-		if ( _this.isMaxFields( field, 1 ) )
+		e.preventDefault();
+		jQuery(this).blur();	
+
+		if ( CMB.isMaxFields( field, 1 ) )
 			return;
 
 	    templateField = field.children( '.field-item.hidden' );
@@ -85,17 +76,23 @@ var CMB = {
 
 		} );
 
-	    _this.clonedField( newT );
+	    CMB.clonedField( newT );
 
 	},
 
-	deleteField : function( fieldItem  ) {
+	deleteField : function( e ) {
 
-		var field = fieldItem.closest( '.field' );
+		var fieldItem, field;
 
-		this.isMaxFields( field, -1 );
+		e.preventDefault();
+		jQuery(this).blur();
+		
+		fieldItem = jQuery( this ).closest('.field-item' );
+		field     = fieldItem.closest( '.field' );
 
-		this.deletedField( fieldItem );
+		CMB.isMaxFields( field, -1 );
+		CMB.deletedField( fieldItem );
+
 		fieldItem.remove();
 
 	},
@@ -149,7 +146,7 @@ var CMB = {
 	doneInit: function() {
 
 		var _this = this,
-			callbacks = _this._initCallbacks;
+			callbacks = CMB._initCallbacks;
 
 		if ( callbacks ) {
 			for ( var a = 0; a < callbacks.length; a++) {
@@ -176,13 +173,11 @@ var CMB = {
 	 */
 	clonedField: function( el ) {
 
-		var _this = this
-
 		// also check child elements
 		el.add( el.find( 'div[data-class]' ) ).each( function( i, el ) {
 
 			el = jQuery( el )
-			var callbacks = _this._clonedFieldCallbacks[el.attr( 'data-class') ]
+			var callbacks = CMB._clonedFieldCallbacks[el.attr( 'data-class') ]
 
 			if ( callbacks )
 				for ( var a = 0; a < callbacks.length; a++ )
@@ -208,13 +203,11 @@ var CMB = {
 	 */
 	deletedField: function( el ) {
 
-		var _this = this;
-
 		// also check child elements
 		el.add( el.find( 'div[data-class]' ) ).each( function(i, el) {
 
 			el = jQuery( el )
-			var callbacks = _this._deletedFieldCallbacks[el.attr( 'data-class') ]
+			var callbacks = CMB._deletedFieldCallbacks[el.attr( 'data-class') ]
 
 			if ( callbacks )
 				for ( var a = 0; a < callbacks.length; a++ )


### PR DESCRIPTION
If a meta box is collapsed (a WordPress feature) then some fields are not initialized on page load. eg select2

We should re-initialize when expanding. easy!

The only issue doing this is that callbacks were getting attached to events multiple times - so I am have updated to use event namespaces and I am unbinding all CMB click events before re-adding. This prevents duplication.

In the process I neatened up the JS a little. I realize that I didn't need to be messing about with `_this` - we can directly access `CMB`
