### PR TITLE
Use divs and CSS to style grid layout instead of tables.

### DIFF
--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -227,7 +227,7 @@ class CMB_Meta_Box {
 
 		<div class="cmb_metabox">
 		
-			<table class="form-table">
+			<div class="cmb-grid">
 
 				<?php $current_colspan = 0;
 
@@ -235,7 +235,7 @@ class CMB_Meta_Box {
 
 					if ( $current_colspan == 0 ) : ?>
 
-						<tr>
+						<div class="cmb-row">
 
 					<?php endif;
 
@@ -259,27 +259,27 @@ class CMB_Meta_Box {
 
 					?>
 
-					<td style="width: <?php esc_attr_e( $field->args['cols'] / 12 * 100 ); ?>%" colspan="<?php esc_attr_e( $field->args['cols'] ); ?>">
+					<div class="cmb-cell-<?php echo intval( $field->args['cols'] ); ?>">
 						
-						<div <?php echo $classes; ?> <?php echo $attrs; ?>>
-							<?php $field->display(); ?>
-						</div>
+							<div <?php echo $classes; ?> <?php echo $attrs; ?>>
+								<?php $field->display(); ?>
+							</div>
 
-						<input type="hidden" name="_cmb_present_<?php esc_attr_e( $field->id ); ?>" value="1" />
+							<input type="hidden" name="_cmb_present_<?php esc_attr_e( $field->id ); ?>" value="1" />
 
-					</td>
+					</div>
 
-					<?php if ( $current_colspan == 12 ) :
+					<?php if ( $current_colspan == 12 || $field === end( $fields ) ) :
 
 						$current_colspan = 0; ?>
 
-						</tr>
+						</div><!-- .cmb-row -->
 
 					<?php endif; ?>
 
 				<?php endforeach; ?>
 
-			</table>
+			</div>
 			
 		</div>
 

--- a/css/src/layout.css
+++ b/css/src/layout.css
@@ -1,24 +1,56 @@
 /** CMB Layout **/
 
-.cmb_metabox .form-table {
-	margin-top: 0;
-}
-
-.cmb_metabox .form-table > tbody > tr > td, 
-.cmb_metabox .form-table > tbody > tr > th { 
-	vertical-align: top; 
-	padding: 0;
-}
-
-.cmb_metabox .form-table tr:last-child > td, 
-.cmb_metabox .form-table tr:last-child > th {
-	border-bottom: 0;
-}
-
 .cmb_metabox .field { 
 	padding: 16px 0;
+	border-bottom: 1px solid #DFDFDF;
 }
 
+.cmb-row:last-child > [class*="cmb-cell-"]  > .field { 
+	border-bottom: 0; 
+}
+
+/* Neaten up the margins when metaboxes are within the standard postbox. */
 .postbox > .inside > .cmb_metabox {
 	margin: -10px 0; 
+}
+
+.cmb-grid .cmb-row { 
+	overflow: hidden; 
+	margin: 0 -5px; 
+	zoom: 1;
+}
+
+.cmb-grid .cmb-row:before,
+.cmb-grid .cmb-row:after {
+    content: "";
+    display: table;
+} 
+.cmb-grid .cmb-row:after {
+    clear: both;
+}
+
+.cmb-grid [class*="cmb-cell-"] { 
+	float: left; 
+	padding: 0 5px;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+}
+
+.cmb-grid .cmb-cell-1  { width: 8.333333333%; }
+.cmb-grid .cmb-cell-2  { width: 16.666666667%; }
+.cmb-grid .cmb-cell-3  { width: 25%; }
+.cmb-grid .cmb-cell-4  { width: 33.333333333%; }
+.cmb-grid .cmb-cell-5  { width: 41.666666667%; }
+.cmb-grid .cmb-cell-6  { width: 50%; }
+.cmb-grid .cmb-cell-7  { width: 58.333333333%; }
+.cmb-grid .cmb-cell-8  { width: 66.666666667%; }
+.cmb-grid .cmb-cell-9  { width: 75%; }
+.cmb-grid .cmb-cell-10 { width: 83.333333333%; }
+.cmb-grid .cmb-cell-11 { width: 91.666666667%; }
+.cmb-grid .cmb-cell-12 { width: 100%; }
+
+@media all and ( max-width: 850px ) {
+
+	.cmb-grid [class*="cmb-cell-"] { width: 100%; }
+
 }


### PR DESCRIPTION
MP6 has done a lot to make the WP admin work better on mobiles.

The CMB column-layout sucked on mobiles. But its not so easy to style tables.

I propose we drop the tables, replacing it with a simple CSS grid, and using media queries to make all columns 100% width below a certain screen width.

Any thoughts - @joehoyle 
