### PR TITLE
Conditionally fix meta query order

### DIFF
--- a/custom-meta-boxes.php
+++ b/custom-meta-boxes.php
@@ -47,7 +47,7 @@ include_once( CMB_PATH . '/class.cmb-meta-box.php' );
 // Make it possible to add fields in locations other than post edit screen.
 include_once( CMB_PATH . '/fields-anywhere.php' );
 
-include_once( CMB_PATH . '/example-functions.php' );
+// include_once( CMB_PATH . '/example-functions.php' );
 
 /**
  * Get all the meta boxes on init


### PR DESCRIPTION
As of 3.8, This fix is no longer required. For the time being I would like to keep this around, to ensure some backwards compatability.

This PR only adds the filter on versions 3.7 and below.

Also fix some indenting.
