### PR TITLE
Date/Time Picker Errors

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -632,7 +632,11 @@ class CMB_Date_Timestamp_Field extends CMB_Field {
 
 		parent::enqueue_scripts();
 
+		wp_enqueue_style( 'cmb-jquery-ui', trailingslashit( CMB_URL ) . 'css/jquery-ui.css', '1.10.3' );
+
+		wp_enqueue_script( 'cmb-timepicker', trailingslashit( CMB_URL ) . 'js/jquery.timePicker.min.js', array( 'jquery', 'cmb-scripts' ) );		
 		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ) );
+
 	}
 
 	public function html() { ?>
@@ -663,7 +667,8 @@ class CMB_Datetime_Timestamp_Field extends CMB_Field {
 		parent::enqueue_scripts();
 
 		wp_enqueue_style( 'cmb-jquery-ui', trailingslashit( CMB_URL ) . 'css/jquery-ui.css', '1.10.3' );
-
+		
+		wp_enqueue_script( 'cmb-timepicker', trailingslashit( CMB_URL ) . 'js/jquery.timePicker.min.js', array( 'jquery', 'cmb-scripts' ) );
 		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ) );
 	}
 


### PR DESCRIPTION
I was using a package manager to pull down the latest version into my themes, but every time I picked datetime_unix as a type the system would start throwing back 

`Uncaught TypeError: Object [object Object] has no method 'datepicker'`

After doing some digging I discovered that the cmb scripts were only listed as being dependent upon jquery so I added the dependency for the datepicker as well.

Fixed! 

Well, kinda...

Then I started getting the same error from timepicker. After setting `global $concatenate_scripts = false;` I was able to see that timepicker wasn't being loaded at all. I tried to figure out why datepicker wouldn't load to no avail.

Instead I went about finding an older version that might not have this issue. I discovered my true love, dbb80695ee59d7b731673cb27d12b14caa66ffc1. This commit works perfectly!

It would seem that a bug was introduced in d8cafcbc6fc28d032f725499cbd129369516e50d, probably in the enqueueing of scripts.
