### PR TITLE
Do not HTML encode post titles in JSON response

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1240,14 +1240,14 @@ function cmb_ajax_post_select() {
 		exit;
 	}
 
-	$args['fields'] = 'ids'; // Only need to retrieve post IDs.
-
 	$query = new WP_Query( $args );
-	
+
 	$json = array( 'total' => $query->found_posts, 'posts' => array() );
 
-	foreach ( $query->posts as $post_id )
-		array_push( $json['posts'], array( 'id' => $post_id, 'text' => get_the_title( $post_id ) ) );
+	while ($query->have_posts()) {
+		$cmb_post = $query->next_post();
+		$json['posts'][] = array( 'id' => $cmb_post->ID, 'text' => $cmb_post->post_title );
+	}
 
 	echo json_encode( $json );
 


### PR DESCRIPTION
Using get_the_title() returns titles with special characters, such as quotes, HTML encoded. Return raw data from WP_Post object instead. Function json_encode() will automatically escape other characters as necessary.
