### PR TITLE
Don't instantiate class if it doesn't exist.

### DIFF
--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -78,8 +78,9 @@ class CMB_Meta_Box {
 			elseif ( $post_id )
 				$values = (array) get_post_meta( $post_id, $field['id'], false );
 
-
-			$this->fields[] = new $class( $field['id'], $field['name'], (array) $values, $field );
+			if ( class_exists( $class ) ) {
+				$this->fields[] = new $class( $field['id'], $field['name'], (array) $values, $field );
+			}
 
 		}
 


### PR DESCRIPTION
If trying to instantiate a field, but the class for that field doesn't exist - it shouldn't cause a fatal error.

See #157
