### PR TITLE
PHP Notice in get_delegate_data when no terms

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1042,6 +1042,10 @@ class CMB_Taxonomy extends CMB_Select {
 
 		$terms = $this->get_terms();
 
+		if ( is_wp_error( $terms ) ) { 
+			return array(); 
+		}
+
 		$term_options = array();
 
 		foreach ( $terms as $term )


### PR DESCRIPTION
Hi Matthew

I was getting a PHP notice in get_delegate_data() in class CMB_Taxonomy so had to add the following code after the get_terms():

```
if (is_object($terms) && get_class($terms)=='WP_Error') { return array(); }
```

Chris
