### PR TITLE
Fix the pattern of preg_replace

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -112,7 +112,7 @@ abstract class CMB_Field {
 		$id = $this->id;
 
 		if ( isset( $this->parent ) ) {
-			$parent_id = preg_replace( '/cmb\-field\-(\d|x)+/', 'cmb-group-$1', $this->parent->get_the_id_attr() );
+			$parent_id = preg_replace( '/cmb\-field\-(\d.|x)+/', 'cmb-group-$1', $this->parent->get_the_id_attr() );
 			$id = $parent_id . '[' . $id . ']';
 		}
 
@@ -153,7 +153,7 @@ abstract class CMB_Field {
 		$name = str_replace( '[]', '', $this->name );
 
 		if ( isset( $this->parent ) ) {
-			$parent_name = preg_replace( '/cmb\-field\-(\d|x)+/', 'cmb-group-$1', $this->parent->get_the_name_attr() );
+			$parent_name = preg_replace( '/cmb\-field\-(\d.|x)+/', 'cmb-group-$1', $this->parent->get_the_name_attr() );
 			$name = $parent_name . '[' . $name . ']';
 		}
 


### PR DESCRIPTION
The bug caused a issue that only 10 repeatable group fields can be updated. 

If the fields are created by the "Add New Group" button, things work well. If they are rendered by PHP, the error happens.

The old pattern will make "cmb-field-10" be replaced as "cmb-group-0", and overwrite the value of previous "cmb-group-0", so there are always only 10 repeatable group fields could be updated, the others would be omitted.
