### PR TITLE
post select ajax single shows currently viewed post

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1190,7 +1190,7 @@ class CMB_Post_Select extends CMB_Select {
 
 						<?php else : ?>
 
-							data = <?php echo json_encode( array( 'id' => $post_id, 'text' => html_entity_decode( get_the_title( $post_id ) ) ) ); ?>;
+							data = <?php echo json_encode( array( 'id' => $post_id, 'text' => html_entity_decode( get_the_title( $this->get_value() ) ) ) ); ?>;
 
 						<?php endif; ?>
 


### PR DESCRIPTION
- Post select field correctly saves data, but then displays the incorrect post (the current post being edited)

I think this is a copy paste fail from a 8c643304236f1edc10b9772c65df037e9c98eef2 which was merged for 1.0 release, so I'm going to merge this ASAP and release version 1.1
