### PR TITLE
WordPress Plugin

### DIFF
--- a/custom-meta-boxes.php
+++ b/custom-meta-boxes.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Custom Meta Boxes
 Plugin URI: https://github.com/humanmade/Custom-Meta-Boxes
-Description: Lets you easily create metaboxes with custom fields that will blow your mind.
+Description: Lets you easily create metaboxes with custom fields that will blow your mind. Originally a fork of https://github.com/jaredatch/Custom-Metaboxes-and-Fields-for-WordPress.
 Version: 1.0.1
 License: GPL-2.0+
 Author: Human Made Limited


### PR DESCRIPTION
Update the header comment to follow the standard used by WordPress plugins
- Yes you can use it as a plugin if you really really want to - that's how WordPress distributes packages
- Compatability with [HM Base mu-plugin autoloader script](https://github.com/humanmade/hm-base/blob/master/content/plugins-mu/loader.php)
- Remove contributors - not easy/feasable to keep this up to date. Github is a good record of contributions.
- Why not?
