### PR TITLE
Hook CMB later - ensure normal init hooks are done

### DIFF
--- a/custom-meta-boxes.php
+++ b/custom-meta-boxes.php
@@ -64,7 +64,7 @@ function cmb_init() {
 			new CMB_Meta_Box( $meta_box );
 
 }
-add_action( 'init', 'cmb_init' );
+add_action( 'init', 'cmb_init', 50 );
 
 /**
  * Return an array of built in available fields


### PR DESCRIPTION
Use case: 

I wanted to programatically create CMB fields based on taxonomy/term data. However - with CMB in MU plugins, this was getting hooked in before the taxonomies were registered.

I think it makes sense to fire this later - to ensure that all normal init stuff has been run before this.
