### PR TITLE
Remove the upload field type hack

### DIFF
--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -86,9 +86,8 @@ class CMB_Meta_Box {
 		wp_localize_script( 'cmb-scripts', 'CMBData', array(
 			'strings' => array(
 				'confirmDeleteField' => __( 'Are you sure you want to delete this field?', 'cmb' )
-				)
 			)
-		);
+		) );
 
 		foreach ( $this->fields as $field )
 			$field->enqueue_scripts();


### PR DESCRIPTION
In the old days - the file upload field required we add the attribut `encoding="multipart/form-data"` to the post edit form. It was a bit hacky really as it had to check whether an upload field was present and then use JS to insert the attribute. But now we're using the proper file uploader - so this isn't actually necessary. 
