### PR TITLE
Repeatable group with more than 1 checkbox renders/saves incorrect values

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1400,10 +1400,10 @@ class CMB_Group_Field extends CMB_Field {
 		// Set values for this field.
 		if ( ! empty( $value ) ) {
 			foreach ( $value as $field_id => $field_value ) {
-				if ( ! empty( $field_value ) && ! empty( $fields[$field_id] ) )
+				$field_value = ( ! empty( $field_value ) ) ? $field_value : array();
+				if ( ! empty( $fields[$field_id] ) ) {
 					$fields[$field_id]->set_values( (array) $field_value );
-				else if ( ! empty( $fields[$field_id] ) )
-					$fields[$field_id]->set_values( array() );
+				}
 			}
 		}
 


### PR DESCRIPTION
Hi, thanks for a great work! I came across something I think is a bug.. consider this matebox:

``` php
$fields = array(
            array( 'id' => 'pricing_features',
                   //'name' => 'Pricing Features',
                   'type' => 'group',
                   'repeatable' => true,
                   'sortable' => true,
                   'fields' => array(
                       array( 'id' => 'pricing_feature',  'name' => '', 'type' => 'text', 'cols' => 6 ),
                       array( 'id' => 'a1',  'name' => '', 'type' => 'checkbox', 'cols' => 2, 'default' => 0 ),
                       array( 'id' => 'b2',  'name' => '', 'type' => 'checkbox', 'cols' => 2, 'default' => 0 ),
                       array( 'id' => 'c3',  'name' => '', 'type' => 'checkbox', 'cols' => 2, 'default' => 0 ),
                   )
            ),
        );
        $meta_boxes[] = array(
            'title' => 'Pricing Features',
            'pages' => 'page',
            'show_on' => array( 'page-template' => array( 'page-pricing.php' ) ),
            'context'    => 'normal',
            'priority'   => 'high',
            'fields' = $fields);
```

When on the page create 2 groups, on the first group created check the second checkbox (b2) and on the second group created check the first box (a1) and then save the page you'll see that when the page refreshes group 1 shows correctly and group 2 have both a1 and b2 checkbox selected even though only a1 was checked.

here's a screenshot of the case:
![screen shot 2014-08-21 at 4 12 36 pm](https://cloud.githubusercontent.com/assets/300232/4001825/f4a8dcb0-2966-11e4-8db8-0b6241082631.png)

Thanks!
