### PR TITLE
Changed order of field init and save hooks

### DIFF
--- a/class.cmb.php
+++ b/class.cmb.php
@@ -40,9 +40,9 @@ abstract class CMB {
 
 		$this->_object_id = $object_id;
 
-		$this->setup_hooks();
-
 		$this->init_fields( $this->args['fields'] );
+		
+		$this->setup_hooks();
 
 	}
 


### PR DESCRIPTION
Data cannot be saved if the fields have not been initialised first.