### PR TITLE
No blank option on taxonomy select type

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -988,7 +988,7 @@ class CMB_wysiwyg extends CMB_Field {
  * @supports "data_delegate"
  * @args
  *     'options'     => array Array of options to show in the select, optionally use data_delegate instead
- *     'allow_none'   => bool Allow no option to be selected (will palce a "None" at the top of the select)
+ *     'allow_none'   => bool|string Allow no option to be selected (will place a "None" at the top of the select)
  *     'multiple'     => bool whether multiple can be selected
  */
 class CMB_Select extends CMB_Field {
@@ -1065,6 +1065,8 @@ class CMB_Select extends CMB_Field {
 		$name = $this->get_the_name_attr();
 		$name .= ! empty( $this->args['multiple'] ) ? '[]' : null;
 
+		$none = is_string( $this->args['allow_none'] ) ? $this->args['allow_none'] : __( 'None', 'cmb' );
+
 		?>
 
 		<select
@@ -1077,8 +1079,8 @@ class CMB_Select extends CMB_Field {
 			style="width: 100%"
 		>
 
-			<?php if ( ! empty( $this->args['allow_none'] ) ) : ?>
-				<option value=""></option>
+			<?php if ( $this->args['allow_none'] ) : ?>
+				<option value=""><?php echo $none; ?></option>
 			<?php endif; ?>
 
 			<?php foreach ( $this->args['options'] as $value => $name ): ?>

--- a/tests/testDateField.php
+++ b/tests/testDateField.php
@@ -18,6 +18,7 @@ class DateFieldsAssetsTestCase extends WP_UnitTestCase {
 	 * Test that all required scripts & styles are correctly loaded.
 	 */
 	function testDateFieldAssets() {
+		global $wp_version;
 
 		$field = new CMB_Date_Field( 'foo', 'Title', array() );		
 			
@@ -33,8 +34,13 @@ class DateFieldsAssetsTestCase extends WP_UnitTestCase {
 		// Scripts
 		$this->assertContains( '/js/field.datetime.js', $scripts_output );
 		$this->assertContains( '/js/cmb.js', $scripts_output );
-		$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/jquery.ui.core.min.js', $scripts_output );
-		$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/jquery.ui.datepicker.min.js', $scripts_output );
+		if ( version_compare( $wp_version, '4.1', '>=' ) ) {
+			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/core.min.js', $scripts_output );
+			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/datepicker.min.js', $scripts_output );
+		} else {
+			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/jquery.ui.core.min.js', $scripts_output );
+			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/jquery.ui.datepicker.min.js', $scripts_output );
+		}
 		
 		// Styles
 		$this->assertContains( 'css/vendor/jquery-ui/jquery-ui.css', $styles_output );


### PR DESCRIPTION
It will be nice to add in the ability to pass an argument that lets people clear the metadata if a term is not required.