### PR TITLE
Fix #282. Add filter for group_field_default_args

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1442,10 +1442,13 @@ class CMB_Group_Field extends CMB_Field {
 	public function get_default_args() {
 		return array_merge(
 			parent::get_default_args(),
-			array(
-				'fields'              => array(),
-				'string-repeat-field' => __( 'Add New Group', 'cmb' ),
-				'string-delete-field' => __( 'Remove Group', 'cmb' ),
+			apply_filters(
+			'cmb_group_field_default_args',
+				array(
+					'fields'              => array(),
+					'string-repeat-field' => __( 'Add New Group', 'cmb' ),
+					'string-delete-field' => __( 'Remove Group', 'cmb' ),
+				)
 			)
 		);
 	}


### PR DESCRIPTION
Add new filter to allow changing of group field button text .. 

Usage example:
```
/**
 * Change the button text of the Group Button 
 */
function change_cmb_group_button_text( $args ) {

	$args['string-repeat-field'] =  __( 'Add New Row', 'cmb' ); // default: Add New Group
	$args['string-delete-field'] =  __( 'Remove Row', 'cmb' );  // default: Remove Group

	return $args;

}
add_filter( 'cmb_group_field_default_args', 'change_cmb_group_button_text' );
```

@mattheu @BronsonQuick comments?