### PR TITLE
Patch to allow gmaps in repeater region

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -333,6 +333,9 @@ abstract class CMB_Field {
 		$this->description();
 
 		$i = 0;
+		if( $this->args['type'] == 'gmap' ) {
+			$values = array( $values );
+		}
 		foreach ( $values as $key => $value ) {
 
 			$this->field_index = $i;


### PR DESCRIPTION
The gmaps meta box doesn't render in the repeater correctly, this patch places all of the maps values within an array before displaying, so the map doesn't repeat itself for each of its variables. 