### PR TITLE
Add fields argument to query array for post select ajax call

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1344,6 +1344,8 @@ class CMB_Post_Select extends CMB_Select {
 
 				<?php if ( $this->args['use_ajax'] ) : ?>
 
+					<?php $this->args['query']['fields'] = 'ids'; ?>
+
 					var ajaxData = {
 						action  : 'cmb_post_select',
 						post_id : '<?php echo intval( get_the_id() ); ?>', // Used for user capabilty check.


### PR DESCRIPTION
Fixes issue where post select form in the admin would keep returning the last ten posts rather than a full list of posts on the site.