### PR TITLE
Prevented error if 'type' not set

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -333,7 +333,7 @@ abstract class CMB_Field {
 		$this->description();
 
 		$i = 0;
-		if( $this->args['type'] == 'gmap' ) {
+		if( isset( $this->args['type'] ) && $this->args['type'] == 'gmap' ) {
 			$values = array( $values );
 		}
 		foreach ( $values as $key => $value ) {


### PR DESCRIPTION
We were getting the following error:

<img width="457" alt="screen shot 2015-11-13 at 13 44 01" src="https://cloud.githubusercontent.com/assets/2066205/11147344/2a17c0e8-8a0d-11e5-8ae8-b0479d5cbce2.png">

So added a check to see if 'type' exists.