### PR TITLE
Google maps remove ‘sensor’ parameter

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1659,7 +1659,7 @@ class CMB_Gmap_Field extends CMB_Field {
 
 		parent::enqueue_scripts();
 
-		wp_enqueue_script( 'cmb-google-maps', '//maps.google.com/maps/api/js?sensor=true&libraries=places' );
+		wp_enqueue_script( 'cmb-google-maps', '//maps.google.com/maps/api/js?libraries=places' );
 		wp_enqueue_script( 'cmb-google-maps-script', trailingslashit( CMB_URL ) . 'js/field-gmap.js', array( 'jquery', 'cmb-google-maps' ) );
 
 		wp_localize_script( 'cmb-google-maps-script', 'CMBGmaps', array(


### PR DESCRIPTION
Developer tools keeps nagging:

`Google Maps API warning: SensorNotRequired https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required`

> The sensor parameter is no longer required for the Google Maps JavaScript API. It won't prevent the Google Maps JavaScript API from working correctly, but we recommend that you remove the sensor parameter from the script element.