### PR TITLE
Add description support for meta box

### DIFF
--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -225,8 +225,22 @@ class CMB_Meta_Box {
 
 	}
 
+	function description() {
+
+		if ( ! empty( $this->_meta_box['desc'] ) ) { ?>
+
+			<div class="cmb_metabox_description">
+				<?php echo wp_kses_post( $this->_meta_box['desc'] ); ?>
+			</div>
+
+		<?php }
+
+	}
+
 	// display fields
-	function show() { ?>
+	function show() {
+
+		$this->description(); ?>
 
 		<input type="hidden" name="wp_meta_box_nonce" value="<?php esc_attr_e( wp_create_nonce( basename(__FILE__) ) ); ?>" />
 


### PR DESCRIPTION
#253.

This PR adds the support for `desc` arg to be passed and displayed on a meta box.

 It does not address the renaming of the html class `cmb_metabox_description` mentioned in this issue.