### PR TITLE
Check if global google is defined

### DIFF
--- a/js/field-gmap.js
+++ b/js/field-gmap.js
@@ -3,6 +3,11 @@
 
 (function($) {
 
+	if ( 'undefined' == typeof google ) {
+		$('.map').css('textAlign','center').append( 'Google Maps API not loaded.' );
+		return;
+	}
+
 	var CMBGmapsInit = function( fieldEl ) {
 
 		var searchInput = $('.map-search', fieldEl ).get(0);


### PR DESCRIPTION
Without an active internet connection the Google maps API script cannot be loaded and the global var `google` will be undefined. This results in an `Uncaught ReferenceError: google is not defined` error which breaks the internets.