### PR TITLE
Use translatable string for maps error message

### DIFF
--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -81,7 +81,8 @@ class CMB_Meta_Box {
 
 		wp_localize_script( 'cmb-scripts', 'CMBData', array(
 			'strings' => array(
-				'confirmDeleteField' => __( 'Are you sure you want to delete this field?', 'cmb' )
+				'confirmDeleteField' => esc_html__( 'Are you sure you want to delete this field?', 'cmb' ),
+				'googleMapsApiNotLoaded' => esc_html__( 'Google Maps API not loaded.', 'cmb' ),
 			)
 		) );
 

--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -82,7 +82,6 @@ class CMB_Meta_Box {
 		wp_localize_script( 'cmb-scripts', 'CMBData', array(
 			'strings' => array(
 				'confirmDeleteField' => esc_html__( 'Are you sure you want to delete this field?', 'cmb' ),
-				'googleMapsApiNotLoaded' => esc_html__( 'Google Maps API not loaded.', 'cmb' ),
 			)
 		) );
 

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1645,12 +1645,13 @@ class CMB_Gmap_Field extends CMB_Field {
 		return array_merge(
 			parent::get_default_args(),
 			array(
-				'field_width'         => '100%',
-				'field_height'        => '250px',
-				'default_lat'         => '51.5073509',
-				'default_long'        => '-0.12775829999998223',
-				'default_zoom'        => '8',
-				'string-marker-title' => __( 'Drag to set the exact location', 'cmb' ),
+				'field_width'                 => '100%',
+				'field_height'                => '250px',
+				'default_lat'                 => '51.5073509',
+				'default_long'                => '-0.12775829999998223',
+				'default_zoom'                => '8',
+				'string-marker-title'         => esc_html__( 'Drag to set the exact location', 'cmb' ),
+				'string-gmaps-api-not-loaded' => esc_html__( 'Google Maps API not loaded.', 'cmb' ),
 			)
 		);
 	}
@@ -1669,7 +1670,8 @@ class CMB_Gmap_Field extends CMB_Field {
 				'zoom'      => $this->args['default_zoom'],
 			),
 			'strings'  => array(
-				'markerTitle' => $this->args['string-marker-title']
+				'markerTitle'            => $this->args['string-marker-title'],
+				'googleMapsApiNotLoaded' => $this->args['string-gmaps-api-not-loaded'],
 			)
 		) );
 

--- a/js/field-gmap.js
+++ b/js/field-gmap.js
@@ -5,17 +5,19 @@
 
 	var CMBGmapsInit = function( fieldEl ) {
 
-		var mapCanvas = $('.map', fieldEl ).get(0);
+		var mapCanvas = $( '.map', fieldEl ).get(0);
 
-		if ( 'undefined' == typeof google ) {
-			$('<div>'+CMBGmaps.strings.googleMapsApiNotLoaded+'</div>').css({'width':'100%','textAlign':'center','marginTop':'1em'}).appendTo( mapCanvas );
+		if ( 'undefined' === typeof google ) {
+			$( '<div>' + CMBGmaps.strings.googleMapsApiNotLoaded + '</div>' )
+				.css({ 'marginTop': '1em', 'textAlign': 'center', 'width': '100%' })
+				.appendTo( mapCanvas );
 			return;
 		}
 
-		var searchInput = $('.map-search', fieldEl ).get(0);
-		var latitude    = $('.latitude', fieldEl );
-		var longitude   = $('.longitude', fieldEl );
-		var elevation   = $('.elevation', fieldEl );
+		var searchInput = $( '.map-search', fieldEl ).get(0);
+		var latitude    = $( '.latitude', fieldEl );
+		var longitude   = $( '.longitude', fieldEl );
+		var elevation   = $( '.elevation', fieldEl );
 		var elevator    = new google.maps.ElevationService();
 
 		var mapOptions = {
@@ -24,7 +26,7 @@
 			mapTypeId: google.maps.MapTypeId.ROADMAP
 		};
 
-		var map      = new google.maps.Map( mapCanvas, mapOptions );
+		var map = new google.maps.Map( mapCanvas, mapOptions );
 
 		// Marker
 		var markerOptions = {

--- a/js/field-gmap.js
+++ b/js/field-gmap.js
@@ -9,7 +9,7 @@
 
 		if ( 'undefined' === typeof google ) {
 			$( '<div>' + CMBGmaps.strings.googleMapsApiNotLoaded + '</div>' )
-				.css({ 'marginTop': '1em', 'textAlign': 'center', 'width': '100%' })
+				.css({ 'padding': '1em', 'textAlign': 'center', 'width': '100%' })
 				.appendTo( mapCanvas );
 			return;
 		}

--- a/js/field-gmap.js
+++ b/js/field-gmap.js
@@ -8,7 +8,7 @@
 		var mapCanvas = $('.map', fieldEl ).get(0);
 
 		if ( 'undefined' == typeof google ) {
-			$('<div>'+CMBData.strings.googleMapsApiNotLoaded+'</div>').css({'width':'100%','textAlign':'center','marginTop':'1em'}).appendTo( mapCanvas );
+			$('<div>'+CMBGmaps.strings.googleMapsApiNotLoaded+'</div>').css({'width':'100%','textAlign':'center','marginTop':'1em'}).appendTo( mapCanvas );
 			return;
 		}
 

--- a/js/field-gmap.js
+++ b/js/field-gmap.js
@@ -10,8 +10,14 @@
 
 	var CMBGmapsInit = function( fieldEl ) {
 
+		var mapCanvas = $('.map', fieldEl ).get(0);
+
+		if ( 'undefined' == typeof google ) {
+			$('<div>'+CMBData.strings.googleMapsApiNotLoaded+'</div>').css({'width':'100%','textAlign':'center','marginTop':'1em'}).appendTo( mapCanvas );
+			return;
+		}
+
 		var searchInput = $('.map-search', fieldEl ).get(0);
-		var mapCanvas   = $('.map', fieldEl ).get(0);
 		var latitude    = $('.latitude', fieldEl );
 		var longitude   = $('.longitude', fieldEl );
 		var elevation   = $('.elevation', fieldEl );

--- a/js/field-gmap.js
+++ b/js/field-gmap.js
@@ -3,11 +3,6 @@
 
 (function($) {
 
-	if ( 'undefined' == typeof google ) {
-		$('.map').css('textAlign','center').append( 'Google Maps API not loaded.' );
-		return;
-	}
-
 	var CMBGmapsInit = function( fieldEl ) {
 
 		var mapCanvas = $('.map', fieldEl ).get(0);


### PR DESCRIPTION
Properly add the ‘Google Maps API not loaded’ error message (introduced in #318) to `CMBGmaps.strings` in stead of hard coding it in the JavaScript file. Additionally adds html escaping.