### PR TITLE
Allow setting Google API key

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1660,7 +1660,13 @@ class CMB_Gmap_Field extends CMB_Field {
 
 		parent::enqueue_scripts();
 
-		wp_enqueue_script( 'cmb-google-maps', '//maps.google.com/maps/api/js?libraries=places' );
+		$maps_src = '//maps.google.com/maps/api/js?libraries=places';
+
+		if ( defined( 'CMB_GAPI_KEY' ) ) {
+			$maps_src = add_query_arg( 'key', urlencode( CMB_GAPI_KEY ), $maps_src );
+		}
+
+		wp_enqueue_script( 'cmb-google-maps', $maps_src );
 		wp_enqueue_script( 'cmb-google-maps-script', trailingslashit( CMB_URL ) . 'js/field-gmap.js', array( 'jquery', 'cmb-google-maps' ) );
 
 		wp_localize_script( 'cmb-google-maps-script', 'CMBGmaps', array(


### PR DESCRIPTION
My Google map fields no longer seem to be working, and I'm getting errors about a missing API key.

Passing the key, as well as granting the correct permissions through the Google API console fixes the issue. I should update the documentation once this is merged.

One concern I have is that my test site hasn't broken.  So I'm not sure of the rules around whether this needs to be defined. Thats why I've kept this optional.