### PR TITLE
Use $this->get_value() in CMB_Number_Field

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -649,7 +649,7 @@ class CMB_Number_Field extends CMB_Field {
 
 	public function html() { ?>
 
-		<input step="<?php echo esc_attr( $this->args['step'] ); ?>" type="number" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_number code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->value ); ?>" />
+		<input step="<?php echo esc_attr( $this->args['step'] ); ?>" type="number" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_number code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->get_value() ); ?>" />
 
 	<?php }
 }


### PR DESCRIPTION
The number field does not display its default value because `$this->value` is used for its value property in stead of `$this->get_value()`.