### PR TITLE
Simplify "Remove Field" label

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -66,7 +66,7 @@ abstract class CMB_Field {
 				'data_delegate'       => null,
 				'save_callback'       => null,
 				'string-repeat-field' => __( 'Add New', 'cmb' ),
-				'string-delete-field' => __( 'Remove Field', 'cmb' ),
+				'string-delete-field' => __( 'Remove', 'cmb' ),
 			),
 			get_class( $this )
 		);


### PR DESCRIPTION
Probably being nitpicky here but: “Remove” might be shorter and sweeter than “Remove Field” as a tool tip for the repeatable field remove button. It is what WordPress uses when editing an image gallery plus it keeps nitpicky persons from needing to add a more specific custom label.

![pasted_image_11_09_16_22_56](https://cloud.githubusercontent.com/assets/4179791/18420485/db44f548-7873-11e6-89e6-038fcfe0928e.jpg)