### PR TITLE
Fix warnings with group fields

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1538,7 +1538,7 @@ class CMB_Group_Field extends CMB_Field {
 	public function html() {
 
 		$fields = &$this->get_fields();
-		$value  = $this->get_value();
+		$value  = $this->get_values();
 
 		// Reset all field values.
 		foreach ( $fields as $field ) {


### PR DESCRIPTION
This is an attempt to fix #349. `CMB_Group_Field::html()` currently causes issues because it uses `$this->get_value()`, which calls `$this->value`. In `\CMB_Field::__construct()`, `$this->value` is set to the first element of `$this->values` (an array of key -> value pairs of field values).

The `foreach()` can't loop over `$this->value` because it is a string.

Our meta box looked like this:

```php
<?php
$meta_boxes[] = array(
	'title'    => 'Foo',
	'pages'    => 'custom-post-type',
	'context'  => 'normal',
	'priority' => 'high',
	'fields'   => array(
		array(
			'id'   => 'first_tab_title',
			'type' => 'text',
			'name' => 'First tab title',
		),
		array(
			'id'         => 'tabs',
			'name'       => 'Tabs',
			'desc'       => '',
			'type'       => 'group',
			'repeatable' => true,
			'sortable'   => true,
			'fields'     => array(
				array(
					'id'   => 'tab_title',
					'name' => 'Title',
					'type' => 'text',
				),
				array(
					'id'      => 'tab_content',
					'name'    => 'Content',
					'type'    => 'wysiwyg',
					'options' => array(
						'textarea_rows' => 10,
					),
				),
			),
		),
	),
);
```