### PR TITLE
Fix check repeatable value exists

### DIFF
--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -43,7 +43,7 @@ class CMB_Meta_Box {
 
 			// If we are on a post edit screen - get metadata value of the field for this post
 			if ( $post_id ) {
-				$single = ! empty( $field['repeatable'] ) ? ! $field['repeatable'] : true;
+				$single = ( ! isset( $field['repeatable'] ) || false === $field['repeatable'] );
 				$values = (array) get_post_meta( $post_id, $field['id'], $single );
 			}
 

--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -43,7 +43,8 @@ class CMB_Meta_Box {
 
 			// If we are on a post edit screen - get metadata value of the field for this post
 			if ( $post_id ) {
-				$values = (array) get_post_meta( $post_id, $field['id'], ! empty( $field['repeatable'] ) );
+				$single = ! empty( $field['repeatable'] ) ? ! $field['repeatable'] : true;
+				$values = (array) get_post_meta( $post_id, $field['id'], $single );
 			}
 
 			if ( class_exists( $class ) ) {


### PR DESCRIPTION
- Checks if `$fields['repeatable']` is set.
  - If it is set, return the inverted value (as passing `false` to `get_post_meta()` means return all values and `true` means return a single value).
  - If `$fields['repeatable']` is empty, return `true` as we’d want to get a single meta value.

This should do the trick. (And apologies for not paying more attention here #338).

Fixes #348, #349, #344 
