### PR TITLE
Load gmaps scripts from JS

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1662,25 +1662,18 @@ class CMB_Gmap_Field extends CMB_Field {
 
 		parent::enqueue_scripts();
 
-		$maps_src = '//maps.google.com/maps/api/js?libraries=places';
+		wp_enqueue_script( 'cmb-google-maps-script', trailingslashit( CMB_URL ) . 'js/field-gmap.js', array( 'jquery' ) );
 
 		// Check for our key with either a field argument or constant.
+		$key = '';
 		if ( ! empty( $this->args['google_api_key'] ) ){
 			$key = $this->args['google_api_key'];
 		} elseif ( defined( 'CMB_GAPI_KEY' ) ) {
 			$key = CMB_GAPI_KEY;
 		}
 
-		// Only add the key argument if it's been set.
-		if ( ! empty( $key ) ) {
-			$maps_src = add_query_arg( 'key', $key, $maps_src );
-		}
-
-		// Enqueue our scripts.
-		wp_enqueue_script( 'cmb-google-maps', $maps_src );
-		wp_enqueue_script( 'cmb-google-maps-script', trailingslashit( CMB_URL ) . 'js/field-gmap.js', array( 'jquery', 'cmb-google-maps' ) );
-
 		wp_localize_script( 'cmb-google-maps-script', 'CMBGmaps', array(
+			'key'      => $key,
 			'defaults' => array(
 				'latitude'  => $this->args['default_lat'],
 				'longitude' => $this->args['default_long'],

--- a/js/field-gmap.js
+++ b/js/field-gmap.js
@@ -100,7 +100,7 @@
 		CMB.addCallbackForClonedField( ['CMB_Gmap_Field'], CMBGmapsInit );
 	};
 
-	$.getScript( 'https://maps.google.com/maps/api/js?sensor=true&libraries=places&callback=CMB_CMAPS_INIT&key=' + CMBGmaps.key );
+	$.getScript( '//maps.google.com/maps/api/js?sensor=true&libraries=places&callback=CMB_CMAPS_INIT&key=' + CMBGmaps.key );
 
 
 }(jQuery));

--- a/js/field-gmap.js
+++ b/js/field-gmap.js
@@ -88,14 +88,19 @@
 			}
 		});
 
-	}
+	};
 
-	CMB.addCallbackForInit( function() {
-		$('.CMB_Gmap_Field .field-item').each(function() {
-			CMBGmapsInit( $(this) );
-		});
-	} );
+	window.CMB_CMAPS_INIT = function() {
+		'use strict';
 
-	CMB.addCallbackForClonedField( ['CMB_Gmap_Field'], CMBGmapsInit );
+		$( '.CMB_Gmap_Field .field-item' ).each( function() {
+			CMBGmapsInit( $( this ) );
+		} );
+
+		CMB.addCallbackForClonedField( ['CMB_Gmap_Field'], CMBGmapsInit );
+	};
+
+	$.getScript( 'https://maps.google.com/maps/api/js?sensor=true&libraries=places&callback=CMB_CMAPS_INIT&key=' + CMBGmaps.key );
+
 
 }(jQuery));


### PR DESCRIPTION
WP encodes gmaps script URL, breaking all arguments after the first `&` , this lazy loads it from JS instead.
