### PR TITLE
Added docblocks and inline documentation

### DIFF
--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -14,7 +14,7 @@
 class CMB_Meta_Box {
 
 	/**
-	 * Meta box group data.
+	 * Meta box set collection data.
 	 *
 	 * @access protected
 	 *
@@ -23,7 +23,7 @@ class CMB_Meta_Box {
 	protected $_meta_box;
 
 	/**
-	 * Fields in a group.
+	 * Fields in a collection.
 	 *
 	 * @access protected
 	 *
@@ -34,13 +34,13 @@ class CMB_Meta_Box {
 	/**
 	 * CMB_Meta_Box constructor.
 	 *
-	 * @param array $meta_box Meta box group.
+	 * @param array $meta_box Meta box collection.
 	 */
 	function __construct( $meta_box ) {
 
 		$this->_meta_box = $meta_box;
 
-		// If group ID is missing, assign the title sanitized to the ID.
+		// If collection ID is missing, assign the title sanitized to the ID.
 		if ( empty( $this->_meta_box['id'] ) )
 			$this->_meta_box['id'] = sanitize_title( $this->_meta_box['title'] );
 
@@ -58,9 +58,9 @@ class CMB_Meta_Box {
 	}
 
 	/**
-	 * Initialize metabox group.
+	 * Initialize metabox box fields.
 	 *
-	 * @action cmb_init_fields
+	 * @uses cmb_init_fields
 	 *
 	 * @param int $post_id Optional. Post ID.
 	 */
@@ -96,7 +96,7 @@ class CMB_Meta_Box {
 	 *
 	 * @global int $post
 	 *
-	 * @action dbx_post_advanced
+	 * @uses dbx_post_advanced
 	 *
 	 * @return bool false if post ID fails or is on wrong screen.
 	 */
@@ -124,7 +124,7 @@ class CMB_Meta_Box {
 	/**
 	 * Load JS scripts in the admin area for plugin use.
 	 *
-	 * @action admin_enqueue_scripts
+	 * @uses admin_enqueue_scripts
 	 */
 	function enqueue_scripts() {
 
@@ -144,7 +144,7 @@ class CMB_Meta_Box {
 	/**
 	 * Load stylesheets in admin area for plugin use.
 	 *
-	 * @action admin_enqueue_styles
+	 * @uses admin_enqueue_styles
 	 */
 	function enqueue_styles() {
 
@@ -161,12 +161,12 @@ class CMB_Meta_Box {
 	}
 
 	/**
-	 * Add a metabox group.
+	 * Add a metabox collection.
 	 *
-	 * Parses a field group for display attributes and runs the WP core functionality
+	 * Parses a field collection for display attributes and runs the WP core functionality
 	 * to register the metabox.
 	 *
-	 * @action admin_menu
+	 * @uses admin_menu
 	 */
 	function add() {
 
@@ -191,8 +191,8 @@ class CMB_Meta_Box {
 	/**
 	 * Handle 'Show On' and 'Hide On' Filters.
 	 *
-	 * Runs checks to see if there are specific compatibilites or incompatibilities for displaying
-	 * a CMB field group.
+	 * Runs checks to see if there are specific compatibilities or incompatibilities for displaying
+	 * a CMB field collection.
 	 */
 	function is_metabox_displayed() {
 		$display = true;
@@ -204,9 +204,9 @@ class CMB_Meta_Box {
 	}
 
 	/**
-	 * Display CMB group for particular post ID.
+	 * Display CMB collection for particular post ID.
 	 *
-	 * Only works for field groups that have the 'show_on' attribute of 'id'.
+	 * Only works for field collections that have the 'show_on' attribute of 'id'.
 	 *
 	 * @param bool $display Current display status.
 	 * @return bool (Potentially) modified display status
@@ -232,9 +232,9 @@ class CMB_Meta_Box {
 	}
 
 	/**
-	 * Hide CMB group for particular post ID.
+	 * Hide CMB collection for particular post ID.
 	 *
-	 * Only works for field groups that have the 'hide_on' attribute of 'id'.
+	 * Only works for field collections that have the 'hide_on' attribute of 'id'.
 	 *
 	 * @param bool $display Current display status.
 	 * @return bool (Potentially) modified display status
@@ -259,9 +259,9 @@ class CMB_Meta_Box {
 	}
 
 	/**
-	 * Display CMB group on pages that have a particular page template assigned.
+	 * Display CMB collection on pages that have a particular page template assigned.
 	 *
-	 * Only works for field groups that have the 'show_on' attribute of 'page-template'.
+	 * Only works for field collections that have the 'show_on' attribute of 'page-template'.
 	 *
 	 * @param bool $display Current display status.
 	 * @return bool (Potentially) modified display status
@@ -289,9 +289,9 @@ class CMB_Meta_Box {
 	}
 
 	/**
-	 * Hide CMB group on pages that have a particular page template assigned.
+	 * Hide CMB collection on pages that have a particular page template assigned.
 	 *
-	 * Only works for field groups that have the 'hide_on' attribute of 'page-template'.
+	 * Only works for field collections that have the 'hide_on' attribute of 'page-template'.
 	 *
 	 * @param bool $display Current display status.
 	 * @return bool (Potentially) modified display status
@@ -320,7 +320,7 @@ class CMB_Meta_Box {
 	}
 
 	/**
-	 * Print out field group description for group.
+	 * Print out field collection description.
 	 */
 	function description() {
 
@@ -335,7 +335,7 @@ class CMB_Meta_Box {
 	}
 
 	/**
-	 * Display fields for a group.
+	 * Display fields for a collection.
 	 */
 	function show() {
 
@@ -352,7 +352,7 @@ class CMB_Meta_Box {
 	 *
 	 * This is a static method so other fields can use it that rely on sub fields.
 	 *
-	 * @param array $fields Fields in a group.
+	 * @param array $fields Fields in a collection.
 	 */
 	static function layout_fields( array $fields ) { ?>
 
@@ -444,7 +444,7 @@ class CMB_Meta_Box {
 	/**
 	 * Save data from metabox.
 	 *
-	 * @action cmb_save_fields
+	 * @uses cmb_save_fields
 	 *
 	 * @param int $post_id Optional. Post ID.
 	 * @return int Post ID if nonce is not verified.
@@ -488,7 +488,7 @@ class CMB_Meta_Box {
 	/**
 	 * Trigger a save the on save_post hook.
 	 *
-	 * @action save_post, edit_attachment
+	 * @uses save_post, edit_attachment
 	 *
 	 * @param int $post_id Post ID.
 	 * @return int Post ID if field is autosaving.
@@ -504,7 +504,7 @@ class CMB_Meta_Box {
 	}
 
 	/**
-	 * Get a post ID for use when populating a metabox group.
+	 * Get a post ID for use when populating a metabox bo.
 	 *
 	 * @return int|null Post ID or null if missing GET variable.
 	 */

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -22,6 +22,8 @@ abstract class CMB_Field {
 	public $value;
 
 	/**
+	 * Current field placement index.
+	 *
 	 * @var int
 	 */
 	public $field_index = 0;
@@ -29,10 +31,10 @@ abstract class CMB_Field {
 	/**
 	 * CMB_Field constructor.
 	 *
-	 * @param       $name
-	 * @param       $title
-	 * @param array $values
-	 * @param array $args
+	 * @param string $name Field name/ID.
+	 * @param string $title Title to display in field.
+	 * @param array  $values Values to populate field(s) with.
+	 * @param array  $args Optional. Field definitions/arguments.
 	 */
 	public function __construct( $name, $title, array $values, $args = array() ) {
 
@@ -213,7 +215,7 @@ abstract class CMB_Field {
 	/**
 	 * Output class attribute for a field.
 	 *
-	 * @param string $classes
+	 * @param string $classes Optional. Classes to assign to the field.
 	 */
 	public function class_attr( $classes = '' ) {
 
@@ -239,9 +241,9 @@ abstract class CMB_Field {
 	}
 
 	/**
-	 * Print an HTML5 attribute for a field.
+	 * Print one or more HTML5 attributes for a field.
 	 *
-	 * @param array $attrs
+	 * @param array $attrs Optional. Attributes to define in the field.
 	 */
 	public function boolean_attr( $attrs = array() ) {
 
@@ -302,7 +304,7 @@ abstract class CMB_Field {
 	/**
 	 * Define multiple values for a field and completely remove the singular value variable.
 	 *
-	 * @param array $values
+	 * @param array $values Field values.
 	 */
 	public function set_values( array $values ) {
 
@@ -332,8 +334,8 @@ abstract class CMB_Field {
 	 * @todo this surely only works for posts
 	 * @todo why do values need to be passed in, they can already be passed in on construct
 	 *
-	 * @param int   $post_id
-	 * @param array $values
+	 * @param int   $post_id Post ID.
+	 * @param array $values Values to save.
 	 */
 	public function save( $post_id, $values ) {
 
@@ -371,7 +373,7 @@ abstract class CMB_Field {
 	}
 
 	/**
-	 *
+	 * Print title for field.
 	 */
 	public function title() {
 
@@ -388,7 +390,7 @@ abstract class CMB_Field {
 	}
 
 	/**
-	 *
+	 * Print description for field.
 	 */
 	public function description() {
 
@@ -403,18 +405,20 @@ abstract class CMB_Field {
 	}
 
 	/**
-	 *
+	 * Print out a field.
 	 */
 	public function display() {
 
-		// If there are no values and it's not repeateble, we want to do one with empty string.
+		// If there are no values and it's not repeatable, we want to do one with empty string.
 		if ( ! $this->get_values() && ! $this->args['repeatable'] )
 			$values = array( '' );
 		else
 			$values = $this->get_values();
 
+		// Print title if necessary.
 		$this->title();
 
+		// Print description if necessary.
 		$this->description();
 
 		$i = 0;
@@ -481,6 +485,9 @@ abstract class CMB_Field {
  */
 class CMB_Text_Field extends CMB_Field {
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() { ?>
 
 		<input type="text" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr(); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->get_value() ); ?>" />
@@ -497,6 +504,9 @@ class CMB_Text_Field extends CMB_Field {
  */
 class CMB_Text_Small_Field extends CMB_Text_Field {
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() {
 
 		$this->args['class'] .= ' cmb_text_small';
@@ -518,9 +528,9 @@ class CMB_Text_Small_Field extends CMB_Text_Field {
 class CMB_File_Field extends CMB_Field {
 
 	/**
-	 * Return the default args for the File field.
+	 * Get default arguments for field including custom parameters.
 	 *
-	 * @return array $args
+	 * @return array Default arguments for field.
 	 */
 	public function get_default_args() {
 		return array_merge(
@@ -531,6 +541,11 @@ class CMB_File_Field extends CMB_Field {
 		);
 	}
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	function enqueue_scripts() {
 
 		global $post_ID;
@@ -543,6 +558,9 @@ class CMB_File_Field extends CMB_Field {
 
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() {
 
 		if ( $this->get_value() ) {
@@ -603,9 +621,9 @@ class CMB_File_Field extends CMB_Field {
 class CMB_Image_Field extends CMB_File_Field {
 
 	/**
-	 * Return the default args for the Image field.
+	 * Get default arguments for field including custom parameters.
 	 *
-	 * @return array $args
+	 * @return array Default arguments for field.
 	 */
 	public function get_default_args() {
 		return array_merge(
@@ -618,6 +636,9 @@ class CMB_Image_Field extends CMB_File_Field {
 		);
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() {
 
 		if ( $this->get_value() )
@@ -748,6 +769,11 @@ add_action( 'wp_ajax_cmb_request_image', array( 'CMB_Image_Field', 'request_imag
  */
 class CMB_Number_Field extends CMB_Field {
 
+	/**
+	 * Get default arguments for field including custom parameters.
+	 *
+	 * @return array Default arguments for field.
+	 */
 	public function get_default_args() {
 		return array_merge(
 			parent::get_default_args(),
@@ -757,6 +783,9 @@ class CMB_Number_Field extends CMB_Field {
 		);
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() { ?>
 
 		<input step="<?php echo esc_attr( $this->args['step'] ); ?>" type="number" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_number code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->get_value() ); ?>" />
@@ -773,6 +802,9 @@ class CMB_Number_Field extends CMB_Field {
  */
 class CMB_URL_Field extends CMB_Field {
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() { ?>
 
 		<input type="text" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_url code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( esc_url( $this->value ) ); ?>" />
@@ -789,12 +821,20 @@ class CMB_URL_Field extends CMB_Field {
  */
 class CMB_Date_Field extends CMB_Field {
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	public function enqueue_scripts() {
 		parent::enqueue_scripts();
 		wp_enqueue_style( 'cmb-jquery-ui', trailingslashit( CMB_URL ) . 'css/vendor/jquery-ui/jquery-ui.css', '1.10.3' );
 		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ) );
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() {
 		// If the user has set a cols arg of less than 6 columns, allow the intput
 		// to go full-width.
@@ -815,6 +855,11 @@ class CMB_Date_Field extends CMB_Field {
  */
 class CMB_Time_Field extends CMB_Field {
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	public function enqueue_scripts() {
 
 		parent::enqueue_scripts();
@@ -825,6 +870,9 @@ class CMB_Time_Field extends CMB_Field {
 		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ) );
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() { ?>
 
 		<input <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_small cmb_timepicker' ); ?> type="text" <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->value ); ?>"/>
@@ -842,6 +890,11 @@ class CMB_Time_Field extends CMB_Field {
  */
 class CMB_Date_Timestamp_Field extends CMB_Field {
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	public function enqueue_scripts() {
 
 		parent::enqueue_scripts();
@@ -853,12 +906,18 @@ class CMB_Date_Timestamp_Field extends CMB_Field {
 
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() { ?>
 
 		<input <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_small cmb_datepicker' ); ?> type="text" <?php $this->name_attr(); ?>  value="<?php echo $this->value ? esc_attr( date( 'm\/d\/Y', $this->value ) ) : '' ?>" />
 
 	<?php }
 
+	/**
+	 * Convert values into UNIX time values and sort.
+	 */
 	public function parse_save_values() {
 
 		foreach( $this->values as &$value )
@@ -879,6 +938,11 @@ class CMB_Date_Timestamp_Field extends CMB_Field {
  */
 class CMB_Datetime_Timestamp_Field extends CMB_Field {
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	public function enqueue_scripts() {
 
 		parent::enqueue_scripts();
@@ -889,6 +953,9 @@ class CMB_Datetime_Timestamp_Field extends CMB_Field {
 		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ) );
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() { ?>
 
 		<input <?php $this->id_attr('date'); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_small cmb_datepicker' ); ?> type="text" <?php $this->name_attr( '[date]' ); ?>  value="<?php echo $this->value ? esc_attr( date( 'm\/d\/Y', $this->value ) ) : '' ?>" />
@@ -896,6 +963,9 @@ class CMB_Datetime_Timestamp_Field extends CMB_Field {
 
 	<?php }
 
+	/**
+	 * Convert values into UNIX time values and sort.
+	 */
 	public function parse_save_values() {
 
 		// Convert all [date] and [time] values to a unix timestamp.
@@ -928,6 +998,9 @@ class CMB_Datetime_Timestamp_Field extends CMB_Field {
  */
 class CMB_Textarea_Field extends CMB_Field {
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() { ?>
 
 		<textarea <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr(); ?> rows="<?php echo ! empty( $this->args['rows'] ) ? esc_attr( $this->args['rows'] ) : 4; ?>" <?php $this->name_attr(); ?>><?php echo esc_textarea( $this->value ); ?></textarea>
@@ -948,6 +1021,9 @@ class CMB_Textarea_Field extends CMB_Field {
  */
 class CMB_Textarea_Field_Code extends CMB_Textarea_Field {
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() {
 
 		$this->args['class'] .= ' code';
@@ -967,6 +1043,11 @@ class CMB_Textarea_Field_Code extends CMB_Textarea_Field {
  */
 class CMB_Color_Picker extends CMB_Field {
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	public function enqueue_scripts() {
 
 		parent::enqueue_scripts();
@@ -975,6 +1056,9 @@ class CMB_Color_Picker extends CMB_Field {
 		wp_enqueue_style( 'wp-color-picker' );
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() { ?>
 
 		<input <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_colorpicker cmb_text_small' ); ?> type="text" <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->get_value() ); ?>" />
@@ -996,9 +1080,9 @@ class CMB_Color_Picker extends CMB_Field {
 class CMB_Radio_Field extends CMB_Field {
 
 	/**
-	 * Return the default args for the Radio input field.
+	 * Get default arguments for field including custom parameters.
 	 *
-	 * @return array $args
+	 * @return array Default arguments for field.
 	 */
 	public function get_default_args() {
 		return array_merge(
@@ -1009,6 +1093,9 @@ class CMB_Radio_Field extends CMB_Field {
 		);
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() {
 
 		if ( $this->has_data_delegate() )
@@ -1036,8 +1123,14 @@ class CMB_Radio_Field extends CMB_Field {
  */
 class CMB_Checkbox extends CMB_Field {
 
+	/**
+	 * Print out field HTML - in this case intentionally empty.
+	 */
 	public function title() {}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() { ?>
 
 		<input <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr(); ?> type="checkbox" <?php $this->name_attr(); ?>  value="1" <?php checked( $this->get_value() ); ?> />
@@ -1057,6 +1150,9 @@ class CMB_Checkbox extends CMB_Field {
  */
 class CMB_Title extends CMB_Field {
 
+	/**
+	 * Print out field HTML - in this case we only want a title.
+	 */
 	public function title() {
 		?>
 
@@ -1070,6 +1166,9 @@ class CMB_Title extends CMB_Field {
 
 	}
 
+	/**
+	 * Placeholder for abstracted method.
+	 */
 	public function html() {}
 
 }
@@ -1084,9 +1183,9 @@ class CMB_Title extends CMB_Field {
 class CMB_wysiwyg extends CMB_Field {
 
 	/**
-	 * Return the default args for the WYSIWYG field.
+	 * Get default arguments for field including custom parameters.
 	 *
-	 * @return array $args
+	 * @return array Default arguments for field.
 	 */
 	public function get_default_args() {
 		return array_merge(
@@ -1097,6 +1196,11 @@ class CMB_wysiwyg extends CMB_Field {
 		);
 	}
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	function enqueue_scripts() {
 
 		parent::enqueue_scripts();
@@ -1104,6 +1208,9 @@ class CMB_wysiwyg extends CMB_Field {
 		wp_enqueue_script( 'cmb-wysiwyg', trailingslashit( CMB_URL ) . 'js/field-wysiwyg.js', array( 'jquery', 'cmb-scripts' ) );
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() {
 
 		$id   = $this->get_the_id_attr();
@@ -1176,6 +1283,9 @@ class CMB_wysiwyg extends CMB_Field {
  */
 class CMB_Select extends CMB_Field {
 
+	/**
+	 * CMB_Select constructor.
+	 */
 	public function __construct() {
 
 		$args = func_get_args();
@@ -1185,9 +1295,9 @@ class CMB_Select extends CMB_Field {
 	}
 
 	/**
-	 * Return the default args for the Select field.
+	 * Get default arguments for field including custom parameters.
 	 *
-	 * @return array $args
+	 * @return array Default arguments for field.
 	 */
 	public function get_default_args() {
 		return array_merge(
@@ -1201,6 +1311,9 @@ class CMB_Select extends CMB_Field {
 		);
 	}
 
+	/**
+	 * Ensure values are saved as an array if multiple is set.
+	 */
 	public function parse_save_values(){
 
 		if ( isset( $this->parent ) && isset( $this->args['multiple'] ) && $this->args['multiple'] )
@@ -1208,6 +1321,11 @@ class CMB_Select extends CMB_Field {
 
 	}
 
+	/**
+	 * Get options for field.
+	 *
+	 * @return mixed
+	 */
 	public function get_options() {
 
 		if ( $this->has_data_delegate() )
@@ -1216,6 +1334,11 @@ class CMB_Select extends CMB_Field {
 		return $this->args['options'];
 	}
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	public function enqueue_scripts() {
 
 		parent::enqueue_scripts();
@@ -1224,6 +1347,11 @@ class CMB_Select extends CMB_Field {
 		wp_enqueue_script( 'field-select', trailingslashit( CMB_URL ) . 'js/field.select.js', array( 'jquery', 'select2', 'cmb-scripts' ) );
 	}
 
+	/**
+	 * Enqueue all styles required by the field.
+	 *
+	 * @uses wp_enqueue_style()
+	 */
 	public function enqueue_styles() {
 
 		parent::enqueue_styles();
@@ -1231,6 +1359,9 @@ class CMB_Select extends CMB_Field {
 		wp_enqueue_style( 'select2', trailingslashit( CMB_URL ) . 'js/vendor/select2/select2.css' );
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() {
 
 		if ( $this->has_data_delegate() )
@@ -1242,6 +1373,9 @@ class CMB_Select extends CMB_Field {
 
 	}
 
+	/**
+	 * Compile field HTML.
+	 */
 	public function output_field() {
 
 		$val = (array) $this->get_value();
@@ -1276,6 +1410,9 @@ class CMB_Select extends CMB_Field {
 		<?php
 	}
 
+	/**
+	 * Output inline scripts to support field.
+	 */
 	public function output_script() {
 
 		$options = wp_parse_args( $this->args['select2_options'], array(
@@ -1316,9 +1453,9 @@ class CMB_Select extends CMB_Field {
 class CMB_Taxonomy extends CMB_Select {
 
 	/**
-	 * Return the default args for the Taxonomy select field.
+	 * Get default arguments for field including custom parameters.
 	 *
-	 * @return array $args
+	 * @return array Default arguments for field.
 	 */
 	public function get_default_args() {
 		return array_merge(
@@ -1330,7 +1467,9 @@ class CMB_Taxonomy extends CMB_Select {
 		);
 	}
 
-
+	/**
+	 * CMB_Taxonomy constructor.
+	 */
 	public function __construct() {
 
 		$args = func_get_args();
@@ -1341,6 +1480,11 @@ class CMB_Taxonomy extends CMB_Select {
 
 	}
 
+	/**
+	 * Retrieve custom field data.
+	 *
+	 * @return array Terms for field data.
+	 */
 	public function get_delegate_data() {
 
 		$terms = $this->get_terms();
@@ -1358,6 +1502,13 @@ class CMB_Taxonomy extends CMB_Select {
 
 	}
 
+	/**
+	 * Get terms for select field.
+	 *
+	 * @todo::cache this or find a cached method
+	 *
+	 * @return array|int|WP_Error
+	 */
 	private function get_terms() {
 
 		return get_terms( $this->args['taxonomy'], array( 'hide_empty' => $this->args['hide_empty'] ) );
@@ -1381,6 +1532,9 @@ class CMB_Taxonomy extends CMB_Select {
  */
 class CMB_Post_Select extends CMB_Select {
 
+	/**
+	 * CMB_Post_Select constructor.
+	 */
 	public function __construct() {
 
 		$args = func_get_args();
@@ -1396,9 +1550,9 @@ class CMB_Post_Select extends CMB_Select {
 		}
 
 	/**
-	 * Return the default args for the Post select field.
+	 * Get default arguments for field including custom parameters.
 	 *
-	 * @return array $args
+	 * @return array Default arguments for field.
 	 */
 	public function get_default_args() {
 		return array_merge(
@@ -1411,6 +1565,13 @@ class CMB_Post_Select extends CMB_Select {
 		);
 	}
 
+	/**
+	 * Get posts and verify for use in select field.
+	 *
+	 * @todo:: validate this data before returning.
+	 *
+	 * @return array Array of posts for field.
+	 */
 	public function get_delegate_data() {
 
 		$data = array();
@@ -1422,6 +1583,11 @@ class CMB_Post_Select extends CMB_Select {
 
 	}
 
+	/**
+	 * Get posts for use in select field.
+	 *
+	 * @return array
+	 */
 	private function get_posts() {
 
 		$this->args['query']['fields'] = 'ids';
@@ -1431,6 +1597,9 @@ class CMB_Post_Select extends CMB_Select {
 
 	}
 
+	/**
+	 * Format the field values for Select2 to read.
+	 */
 	public function parse_save_value() {
 
 		// AJAX multi select2 data is submitted as a string of comma separated post IDs.
@@ -1441,6 +1610,9 @@ class CMB_Post_Select extends CMB_Select {
 
 	}
 
+	/**
+	 * Assemble and output of field HTML.
+	 */
 	public function output_field() {
 
 		// If AJAX, must use input type not standard select.
@@ -1468,6 +1640,9 @@ class CMB_Post_Select extends CMB_Select {
 
 	}
 
+	/**
+	 * Output inline scripts to support field.
+	 */
 	public function output_script() {
 
 		parent::output_script();
@@ -1553,7 +1728,7 @@ class CMB_Post_Select extends CMB_Select {
 }
 
 /**
- *
+ * AJAX callback for select fields.
  *
  * @todo:: this should be in inside the class.
  */
@@ -1586,7 +1761,7 @@ function cmb_ajax_post_select() {
 add_action( 'wp_ajax_cmb_post_select', 'cmb_ajax_post_select' );
 
 /**
- * Field to group child fieids
+ * Field to group child fields
  * pass $args[fields] array for child fields
  * pass $args['repeatable'] for cloing all child fields (set)
  *
@@ -1599,8 +1774,17 @@ add_action( 'wp_ajax_cmb_post_select', 'cmb_ajax_post_select' );
 class CMB_Group_Field extends CMB_Field {
 
 	static $added_js;
+
+	/**
+	 * Fields arguments and information.
+	 *
+	 * @var array
+	 */
 	private $fields = array();
 
+	/**
+	 * CMB_Group_Field constructor.
+	 */
 	function __construct() {
 
 		// You can't just put func_get_args() into a function as a parameter.
@@ -1619,9 +1803,9 @@ class CMB_Group_Field extends CMB_Field {
 	}
 
 	/**
-	 * Return the default args for the Group field.
+	 * Get default arguments for field including custom parameters.
 	 *
-	 * @return array $args
+	 * @return array Default arguments for field.
 	 */
 	public function get_default_args() {
 		return array_merge(
@@ -1634,6 +1818,11 @@ class CMB_Group_Field extends CMB_Field {
 		);
 	}
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	public function enqueue_scripts() {
 
 		parent::enqueue_scripts();
@@ -1646,6 +1835,11 @@ class CMB_Group_Field extends CMB_Field {
 
 	}
 
+	/**
+	 * Enqueue all styles required by the field.
+	 *
+	 * @uses wp_enqueue_style()
+	 */
 	public function enqueue_styles() {
 
 		parent::enqueue_styles();
@@ -1658,6 +1852,9 @@ class CMB_Group_Field extends CMB_Field {
 
 	}
 
+	/**
+	 * Display output for group.
+	 */
 	public function display() {
 
 		global $post;
@@ -1713,6 +1910,9 @@ class CMB_Group_Field extends CMB_Field {
 
 	}
 
+	/**
+	 * Print out group field HTML.
+	 */
 	public function html() {
 
 		$fields = &$this->get_fields();
@@ -1746,6 +1946,9 @@ class CMB_Group_Field extends CMB_Field {
 
 	<?php }
 
+	/**
+	 * Parse values individually based on what kind of field they are.
+	 */
 	public function parse_save_values() {
 
 		$fields = &$this->get_fields();
@@ -1774,15 +1977,30 @@ class CMB_Group_Field extends CMB_Field {
 
 	}
 
+	/**
+	 * Add assigned fields to group data.
+	 *
+	 * @param CMB_Field $field Field object.
+	 */
 	public function add_field( CMB_Field $field ) {
 		$field->parent = $this;
 		$this->fields[$field->id] = $field;
 	}
 
+	/**
+	 * Assemble all defined fields for group.
+	 *
+	 * @return array
+	 */
 	public function &get_fields() {
 		return $this->fields;
 	}
 
+	/**
+	 * Set values for each field in the group.
+	 *
+	 * @param array $values Existing or default values for all fields.
+	 */
 	public function set_values( array $values ) {
 
 		$fields       = &$this->get_fields();
@@ -1819,9 +2037,9 @@ class CMB_Group_Field extends CMB_Field {
 class CMB_Gmap_Field extends CMB_Field {
 
 	/**
-	 * Return the default args for the Map field.
+	 * Get default arguments for field including custom parameters.
 	 *
-	 * @return array $args
+	 * @return array Default arguments for field.
 	 */
 	public function get_default_args() {
 		return array_merge(
@@ -1839,6 +2057,11 @@ class CMB_Gmap_Field extends CMB_Field {
 		);
 	}
 
+	/**
+	 * Enqueue all scripts required by the field.
+	 *
+	 * @uses wp_enqueue_script()
+	 */
 	public function enqueue_scripts() {
 
 		parent::enqueue_scripts();
@@ -1868,6 +2091,9 @@ class CMB_Gmap_Field extends CMB_Field {
 
 	}
 
+	/**
+	 * Print out field HTML.
+	 */
 	public function html() {
 
 		// Ensure all args used are set.

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * All HM CMB field classes and definitions.
+ *
+ * @package WordPress
+ * @subpackage Custom Meta Boxes
+ */
 
 /**
  * Abstract class for all fields.
@@ -8,9 +14,26 @@
  */
 abstract class CMB_Field {
 
+	/**
+	 * Current field value.
+	 *
+	 * @var mixed
+	 */
 	public $value;
+
+	/**
+	 * @var int
+	 */
 	public $field_index = 0;
 
+	/**
+	 * CMB_Field constructor.
+	 *
+	 * @param       $name
+	 * @param       $title
+	 * @param array $values
+	 * @param array $args
+	 */
 	public function __construct( $name, $title, array $values, $args = array() ) {
 
 		$this->id 		= $name;
@@ -32,7 +55,7 @@ abstract class CMB_Field {
 			$this->args['options'] = $re_format;
 		}
 
-		// If the field has a custom value populator callback
+		// If the field has a custom value populator callback.
 		if ( ! empty( $args['values_callback'] ) )
 			$this->values = call_user_func( $args['values_callback'], get_the_id() );
 		else
@@ -97,8 +120,7 @@ abstract class CMB_Field {
 	 * If multiple inputs are required for a single field,
 	 * use the append parameter to add unique identifier.
 	 *
-	 * @param  string $append
-	 * @return null
+	 * @param  string $append Optional. ID to place.
 	 */
 	public function id_attr( $append = null ) {
 
@@ -109,13 +131,11 @@ abstract class CMB_Field {
 	/**
 	 * Output the for attribute for the field.
 	 *
-	 *
-	 *
 	 * If multiple inputs are required for a single field,
 	 * use the append parameter to add unique identifier.
 	 *
-	 * @param  string $append
-	 * @return null
+	 * @param  string $append Optional. ID to place.
+	 * @return string Modified id attribute contents
 	 */
 	public function get_the_id_attr( $append = null ) {
 
@@ -138,13 +158,14 @@ abstract class CMB_Field {
 	}
 
 	/**
-	 * Return the field input ID attribute value.
+	 * Output the field input ID attribute value.
 	 *
 	 * If multiple inputs are required for a single field,
 	 * use the append parameter to add unique identifier.
 	 *
-	 * @param  string $append
-	 * @return string id attribute value.
+	 * @see get_the_id_attr
+	 *
+	 * @param string $append Optional. for value to place.
 	 */
 	public function for_attr( $append = null ) {
 
@@ -152,12 +173,25 @@ abstract class CMB_Field {
 
 	}
 
+	/**
+	 * Output HTML name attribute for a field.
+	 *
+	 * @see get_the_name_attr
+	 *
+	 * @param string $append Optional. Name to place.
+	 */
 	public function name_attr( $append = null ) {
 
 		printf( 'name="%s"', esc_attr( $this->get_the_name_attr( $append ) ) );
 
 	}
 
+	/**
+	 * Get the name attribute contents for a field.
+	 *
+	 * @param null $append Optional. Name to place.
+	 * @return string Name attribute contents.
+	 */
 	public function get_the_name_attr( $append = null ) {
 
 		$name = str_replace( '[]', '', $this->name );
@@ -176,6 +210,11 @@ abstract class CMB_Field {
 
 	}
 
+	/**
+	 * Output class attribute for a field.
+	 *
+	 * @param string $classes
+	 */
 	public function class_attr( $classes = '' ) {
 
 		if ( $classes = implode( ' ', array_map( 'sanitize_html_class', array_filter( array_unique( explode( ' ', $classes . ' ' . $this->args['class'] ) ) ) ) ) ) { ?>
@@ -190,13 +229,20 @@ abstract class CMB_Field {
 	 * Get JS Safe ID.
 	 *
 	 * For use as a unique field identifier in javascript.
+	 *
+	 * @return string JS-escaped ID string.
 	 */
 	public function get_js_id() {
 
-		return str_replace( array( '-', '[', ']', '--' ),'_', $this->get_the_id_attr() ); // JS friendly ID
+		return str_replace( array( '-', '[', ']', '--' ),'_', $this->get_the_id_attr() );
 
 	}
 
+	/**
+	 * Print an HTML5 attribute for a field.
+	 *
+	 * @param array $attrs
+	 */
 	public function boolean_attr( $attrs = array() ) {
 
 		if ( $this->args['readonly'] )
@@ -215,14 +261,14 @@ abstract class CMB_Field {
 	/**
 	 * Check if this field has a data delegate set
 	 *
-	 * @return boolean
+	 * @return boolean Set or turned off.
 	 */
 	public function has_data_delegate() {
 		return (bool) $this->args['data_delegate'];
 	}
 
 	/**
-	 * Get the array of data from the data delegate
+	 * Get the array of data from the data delegate.
 	 *
 	 * @return array mixed
 	 */
@@ -235,14 +281,29 @@ abstract class CMB_Field {
 
 	}
 
+	/**
+	 * Get the existing or default value for a field.
+	 *
+	 * @return mixed
+	 */
 	public function get_value() {
 	   return ( $this->value || $this->value === '0' ) ? $this->value : $this->args['default'];
 	}
 
+	/**
+	 * Get multiple values for a field.
+	 *
+	 * @return array
+	 */
 	public function &get_values() {
 		return $this->values;
 	}
 
+	/**
+	 * Define multiple values for a field and completely remove the singular value variable.
+	 *
+	 * @param array $values
+	 */
 	public function set_values( array $values ) {
 
 		$this->values = $values;
@@ -251,13 +312,28 @@ abstract class CMB_Field {
 
 	}
 
+	/**
+	 * Parse and validate an array of values.
+	 *
+	 * Meant to be extended.
+	 */
 	public function parse_save_values() {}
 
+	/**
+	 * Parse and validate a single value.
+	 *
+	 * Meant to be extended.
+	 */
 	public function parse_save_value() {}
 
 	/**
+	 * Save values for the field.
+	 *
 	 * @todo this surely only works for posts
 	 * @todo why do values need to be passed in, they can already be passed in on construct
+	 *
+	 * @param int   $post_id
+	 * @param array $values
 	 */
 	public function save( $post_id, $values ) {
 
@@ -268,7 +344,7 @@ abstract class CMB_Field {
 		$this->values = $values;
 		$this->parse_save_values();
 
-		// Allow override from args
+		// Allow override from args.
 		if ( ! empty( $this->args['save_callback'] ) ) {
 
 			call_user_func( $this->args['save_callback'], $this->values, $post_id );
@@ -277,7 +353,7 @@ abstract class CMB_Field {
 
 		}
 
-		// If we are not on a post edit screen
+		// If we are not on a post edit screen.
 		if ( ! $post_id )
 			return;
 
@@ -294,6 +370,9 @@ abstract class CMB_Field {
 		}
 	}
 
+	/**
+	 *
+	 */
 	public function title() {
 
 		if ( $this->title ) { ?>
@@ -308,6 +387,9 @@ abstract class CMB_Field {
 
 	}
 
+	/**
+	 *
+	 */
 	public function description() {
 
 		if ( ! empty( $this->args['desc'] ) ) { ?>
@@ -320,9 +402,12 @@ abstract class CMB_Field {
 
 	}
 
+	/**
+	 *
+	 */
 	public function display() {
 
-		// If there are no values and it's not repeateble, we want to do one with empty string
+		// If there are no values and it's not repeateble, we want to do one with empty string.
 		if ( ! $this->get_values() && ! $this->args['repeatable'] )
 			$values = array( '' );
 		else
@@ -359,10 +444,11 @@ abstract class CMB_Field {
 
 		}
 
-		// Insert a hidden one if it's repeatable
+		// Insert a hidden one if it's repeatable.
 		if ( $this->args['repeatable'] ) {
 
-			$this->field_index = 'x'; // x used to distinguish hidden fields.
+			// X used to distinguish hidden fields.
+			$this->field_index = 'x';
 			$this->value = ''; ?>
 
 			<div class="field-item hidden" data-class="<?php echo esc_attr( get_class( $this ) ); ?>" style="position: relative; <?php echo esc_attr( $this->args['style'] ); ?>">
@@ -389,6 +475,8 @@ abstract class CMB_Field {
 /**
  * Standard text field.
  *
+ * @since 1.0.0
+ *
  * @extends CMB_Field
  */
 class CMB_Text_Field extends CMB_Field {
@@ -400,6 +488,13 @@ class CMB_Text_Field extends CMB_Field {
 	<?php }
 }
 
+/**
+ * Small text field.
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Text_Field
+ */
 class CMB_Text_Small_Field extends CMB_Text_Field {
 
 	public function html() {
@@ -412,9 +507,13 @@ class CMB_Text_Small_Field extends CMB_Text_Field {
 }
 
 /**
- * Field for image upload / file updoad.
+ * Field for image upload / file upload.
  *
  * @todo ability to set image size (preview image) from caller
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_File_Field extends CMB_Field {
 
@@ -494,6 +593,13 @@ class CMB_File_Field extends CMB_Field {
 
 }
 
+/**
+ * Field for image upload.
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_File_Field
+ */
 class CMB_Image_Field extends CMB_File_Field {
 
 	/**
@@ -517,10 +623,10 @@ class CMB_Image_Field extends CMB_File_Field {
 		if ( $this->get_value() )
 			$image = wp_get_attachment_image_src( $this->get_value(), $this->args['size'], true );
 
-		// Convert size arg to array of width, height, crop
+		// Convert size arg to array of width, height, crop.
 		$size = $this->parse_image_size( $this->args['size'] );
 
-		// Inline styles
+		// Inline styles.
 		$styles              = sprintf( 'width: %1$dpx; height: %2$dpx; line-height: %2$dpx', intval( $size['width'] ), intval( $size['height'] ) );
 		$placeholder_styles  = sprintf( 'width: %dpx; height: %dpx;', intval( $size['width'] ) - 8, intval( $size['height'] ) - 8 );
 
@@ -569,12 +675,12 @@ class CMB_Image_Field extends CMB_File_Field {
 	/**
 	 * Parse the size argument to get pixel width, pixel height and crop information.
 	 *
-	 * @param  string $size
+	 * @param string $size Size of image requested.
 	 * @return array width, height, crop
 	 */
 	private function parse_image_size( $size ) {
 
-		// Handle string for built-in image sizes
+		// Handle string for built-in image sizes.
 		if ( is_string( $size ) && in_array( $size, array( 'thumbnail', 'medium', 'large' ) ) ) {
 			return array(
 				'width'  => get_option( $size . '_size_w' ),
@@ -583,7 +689,7 @@ class CMB_Image_Field extends CMB_File_Field {
 			);
 		}
 
-		// Handle string for additional image sizes
+		// Handle string for additional image sizes.
 		global $_wp_additional_image_sizes;
 		if ( is_string( $size ) && isset( $_wp_additional_image_sizes[$size] ) ) {
 			return array(
@@ -626,15 +732,19 @@ class CMB_Image_Field extends CMB_File_Field {
 		$image = wp_get_attachment_image_src( $id, $size );
 		echo reset( $image );
 
-		die(); // this is required to return a proper result
+		// This is required to return a proper result.
+		die();
 	}
 
 }
 add_action( 'wp_ajax_cmb_request_image', array( 'CMB_Image_Field', 'request_image_ajax_callback' ) );
 
 /**
- * Standard text meta box for a URL.
+ * Number meta box for a URL.
  *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Number_Field extends CMB_Field {
 
@@ -657,6 +767,9 @@ class CMB_Number_Field extends CMB_Field {
 /**
  * Standard text meta box for a URL.
  *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_URL_Field extends CMB_Field {
 
@@ -668,8 +781,11 @@ class CMB_URL_Field extends CMB_Field {
 }
 
 /**
- * Date picker box.
+ * Date picker meta box field.
  *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Date_Field extends CMB_Field {
 
@@ -690,6 +806,13 @@ class CMB_Date_Field extends CMB_Field {
 	<?php }
 }
 
+/**
+ * Time picker meta box field.
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
+ */
 class CMB_Time_Field extends CMB_Field {
 
 	public function enqueue_scripts() {
@@ -713,6 +836,9 @@ class CMB_Time_Field extends CMB_Field {
 /**
  * Date picker for date only (not time) box.
  *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Date_Timestamp_Field extends CMB_Field {
 
@@ -747,6 +873,9 @@ class CMB_Date_Timestamp_Field extends CMB_Field {
 /**
  * Date picker for date and time (seperate fields) box.
  *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Datetime_Timestamp_Field extends CMB_Field {
 
@@ -792,6 +921,10 @@ class CMB_Datetime_Timestamp_Field extends CMB_Field {
  *
  * Args:
  *  - int "rows" - number of rows in the <textarea>
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Textarea_Field extends CMB_Field {
 
@@ -808,6 +941,10 @@ class CMB_Textarea_Field extends CMB_Field {
  *
  * Args:
  *  - int "rows" - number of rows in the <textarea>
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Textarea_Field
  */
 class CMB_Textarea_Field_Code extends CMB_Textarea_Field {
 
@@ -824,6 +961,9 @@ class CMB_Textarea_Field_Code extends CMB_Textarea_Field {
 /**
  *  Colour picker
  *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Color_Picker extends CMB_Field {
 
@@ -848,6 +988,10 @@ class CMB_Color_Picker extends CMB_Field {
  *
  * Args:
  *  - bool "inline" - display the radio buttons inline
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Radio_Field extends CMB_Field {
 
@@ -886,6 +1030,9 @@ class CMB_Radio_Field extends CMB_Field {
 /**
  * Standard checkbox field.
  *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Checkbox extends CMB_Field {
 
@@ -904,6 +1051,9 @@ class CMB_Checkbox extends CMB_Field {
 /**
  * Standard title used as a splitter.
  *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Title extends CMB_Field {
 
@@ -925,8 +1075,11 @@ class CMB_Title extends CMB_Field {
 }
 
 /**
- * wysiwyg field.
+ * WYSIWYG field.
  *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_wysiwyg extends CMB_Field {
 
@@ -1016,6 +1169,10 @@ class CMB_wysiwyg extends CMB_Field {
  *     'options'     => array Array of options to show in the select, optionally use data_delegate instead
  *     'allow_none'   => bool|string Allow no option to be selected (will place a "None" at the top of the select)
  *     'multiple'     => bool whether multiple can be selected
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Select extends CMB_Field {
 
@@ -1149,6 +1306,13 @@ class CMB_Select extends CMB_Field {
 
 }
 
+/**
+ * Taxonomy-specific select field.
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Select
+ */
 class CMB_Taxonomy extends CMB_Select {
 
 	/**
@@ -1208,8 +1372,12 @@ class CMB_Taxonomy extends CMB_Select {
  * @supports "data_delegate"
  * @args
  *     'options'     => array Array of options to show in the select, optionally use data_delegate instead
- *     'allow_none'   => bool Allow no option to be selected (will palce a "None" at the top of the select)
+ *     'allow_none'   => bool Allow no option to be selected (will place a "None" at the top of the select)
  *     'multiple'     => bool whether multiple can be selected
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Select
  */
 class CMB_Post_Select extends CMB_Select {
 
@@ -1384,7 +1552,11 @@ class CMB_Post_Select extends CMB_Select {
 
 }
 
-// TODO this should be in inside the class
+/**
+ *
+ *
+ * @todo:: this should be in inside the class.
+ */
 function cmb_ajax_post_select() {
 
 	$post_id = ! empty( $_POST['post_id'] ) ? intval( $_POST['post_id'] ) : false;
@@ -1419,6 +1591,10 @@ add_action( 'wp_ajax_cmb_post_select', 'cmb_ajax_post_select' );
  * pass $args['repeatable'] for cloing all child fields (set)
  *
  * @todo remove global $post reference, somehow
+ *
+ * @since 1.0.0
+ *
+ * @extends CMB_Field
  */
 class CMB_Group_Field extends CMB_Field {
 
@@ -1427,7 +1603,8 @@ class CMB_Group_Field extends CMB_Field {
 
 	function __construct() {
 
-		$args = func_get_args(); // you can't just put func_get_args() into a function as a parameter
+		// You can't just put func_get_args() into a function as a parameter.
+		$args = func_get_args();
 		call_user_func_array( array( 'parent', '__construct' ), $args );
 
 		if ( ! empty( $this->args['fields'] ) ) {
@@ -1519,7 +1696,7 @@ class CMB_Group_Field extends CMB_Field {
 
 		if ( $this->args['repeatable'] ) {
 
-			$this->field_index = 'x'; // x used to distinguish hidden fields.
+			$this->field_index = 'x'; // X used to distinguish hidden fields.
 			$this->value = '';
 
 			?>
@@ -1588,8 +1765,8 @@ class CMB_Group_Field extends CMB_Field {
 
 				$field_value = $field->get_values();
 
-				// if the field is a repeatable field, store the whole array of them, if it's not repeatble,
-				// just store the first (and only) one directly
+				// If the field is a repeatable field, store the whole array of them, if it's not repeatable,
+				// just store the first (and only) one directly.
 				if ( ! $field->args['repeatable'] )
 					$field_value = reset( $field_value );
 			}
@@ -1633,7 +1810,11 @@ class CMB_Group_Field extends CMB_Field {
  * It enables the google places API and doesn't store the place
  * name. It only stores latitude and longitude of the selected area.
  *
- * Note
+ * Note - you need a Google API key for field to work correctly.
+ *
+ * @since 1.0.2
+ *
+ * @extends CMB_Field
  */
 class CMB_Gmap_Field extends CMB_Field {
 
@@ -1689,7 +1870,7 @@ class CMB_Gmap_Field extends CMB_Field {
 
 	public function html() {
 
-		// Ensure all args used are set
+		// Ensure all args used are set.
 		$value = wp_parse_args(
 			$this->get_value(),
 			array(

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -761,7 +761,7 @@ class CMB_Image_Field extends CMB_File_Field {
 add_action( 'wp_ajax_cmb_request_image', array( 'CMB_Image_Field', 'request_image_ajax_callback' ) );
 
 /**
- * Number meta box for a URL.
+ * Number meta box.
  *
  * @since 1.0.0
  *

--- a/custom-meta-boxes.php
+++ b/custom-meta-boxes.php
@@ -31,25 +31,27 @@ if ( ! defined( 'CMB_PATH') )
 if ( ! defined( 'CMB_URL' ) )
 	define( 'CMB_URL', plugins_url( '', __FILE__ ) );
 
+/**
+ * Include base, required files.
+ */
 include_once( CMB_PATH . '/classes.fields.php' );
 include_once( CMB_PATH . '/class.cmb-meta-box.php' );
 
-// Make it possible to add fields in locations other than post edit screen.
+/**
+ * Make it possible to add fields in locations other than post edit screen. Optional.
+ */
 include_once( CMB_PATH . '/fields-anywhere.php' );
 
-// include_once( CMB_PATH . '/example-functions.php' );
-
 /**
- * Get all the meta boxes on init
- *
- * @return null
+ * Get all the meta boxes on init.
  */
 function cmb_init() {
 
+	// Only run in the admin.
 	if ( ! is_admin() )
 		return;
 
-	// Load translations
+	// Load translations.
 	$textdomain = 'cmb';
 	$locale = apply_filters( 'plugin_locale', get_locale(), $textdomain );
 
@@ -59,6 +61,7 @@ function cmb_init() {
 
 	$meta_boxes = apply_filters( 'cmb_meta_boxes', array() );
 
+	// Ensure that we have metaboxes to process.
 	if ( ! empty( $meta_boxes ) )
 		foreach ( $meta_boxes as $meta_box )
 			new CMB_Meta_Box( $meta_box );
@@ -67,15 +70,20 @@ function cmb_init() {
 add_action( 'init', 'cmb_init', 50 );
 
 /**
- * Return an array of built in available fields
+ * Return an array of built in available fields.
  *
  * Key is field name, Value is class used by field.
  * Available fields can be modified using the 'cmb_field_types' filter.
  *
- * @return array
+ * @return array List of all available fields.
  */
 function _cmb_available_fields() {
 
+	/**
+	 * Filter and potentially modify the available field types.
+	 *
+	 * @param $types All available field types.
+	 */
 	return apply_filters( 'cmb_field_types', array(
 		'text'				=> 'CMB_Text_Field',
 		'text_small' 		=> 'CMB_Text_Small_Field',
@@ -105,10 +113,10 @@ function _cmb_available_fields() {
 }
 
 /**
- * Get a field class by type
+ * Get a field class by type.
  *
- * @param  string $type
- * @return string $class, or false if not found.
+ * @param  string $type Type of field (i.e. text, number, radio).
+ * @return string|bool $class, or false if not found.
  */
 function _cmb_field_class_for_type( $type ) {
 
@@ -128,8 +136,8 @@ function _cmb_field_class_for_type( $type ) {
  * Only do this for older versions as meta is now ordered by ID (since 3.8)
  * See http://core.trac.wordpress.org/ticket/25511
  *
- * @param  string $query
- * @return string $query
+ * @param  string $query SQL query.
+ * @return string $query (Potentially) modified query string
  */
 function cmb_fix_meta_query_order($query) {
 
@@ -156,5 +164,9 @@ function cmb_fix_meta_query_order($query) {
 
 }
 
+/**
+ * Only run query modification for older versions as meta is now ordered by ID (since 3.8)
+ * See http://core.trac.wordpress.org/ticket/25511
+ */
 if ( version_compare( get_bloginfo( 'version' ), '3.8', '<' ) )
 	add_filter( 'query', 'cmb_fix_meta_query_order', 1 );

--- a/example-functions.php
+++ b/example-functions.php
@@ -1,13 +1,22 @@
 <?php
 /**
+ * Example functions to reference for developers.
+ *
+ * @package WordPress
+ * @subpackage Custom Meta Boxes
+ */
+
+/**
  * Define the metabox and field configurations.
  *
- * @param  array $meta_boxes
+ * @param  array $meta_boxes Existing metaboxes.
  * @return array
  */
 function cmb_sample_metaboxes( array $meta_boxes ) {
 
-	// Example of all available fields
+	/**
+	 * Example of all available fields.
+	 */
 
 	$fields = array(
 
@@ -56,7 +65,9 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		'fields' => $fields
 	);
 
-	// Examples of Groups and Columns
+	/**
+	 * Examples of Groups and Columns.
+	 */
 
 	$groups_and_cols = array(
 		array( 'id' => 'gac-1',  'name' => 'Text input field', 'type' => 'text', 'cols' => 4 ),
@@ -77,8 +88,11 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		'fields' => $groups_and_cols
 	);
 
-	// Example of repeatable group. Using all fields.
-	// For this example, copy fields from $fields, update I
+	/**
+	 * Example of repeatable group. Using all fields.
+	 * For this example, copy fields from $fields, update ID.
+	 */
+
 	$group_fields = $fields;
 	foreach ( $group_fields as &$field ) {
 		$field['id'] = str_replace( 'field', 'gfield', $field['id'] );

--- a/fields-anywhere.php
+++ b/fields-anywhere.php
@@ -1,15 +1,19 @@
-<?php 
-
+<?php
 /**
  * Create CMB Meta boxes anywhere you like (other than the post edit screen).
  *
  * This is functional, but a little hacky.
+ *
+ * @package WordPress
+ * @subpackage Custom Meta Boxes
  */
 
 /**
- * Draw the meta boxes in places other than the post edit screen
- * 
- * @return null
+ * Draw the meta boxes in places other than the post edit screen.
+ *
+ * @param string|object $screen Screen identifier.
+ * @param string        $context Optional. box context.
+ * @param mixed         $object gets passed to the box callback function as first parameter.
  */
 function cmb_draw_meta_boxes( $pages, $context = 'normal', $object = null ) {
 
@@ -22,11 +26,9 @@ function cmb_draw_meta_boxes( $pages, $context = 'normal', $object = null ) {
 /**
  * Meta-Box template function
  *
- * @since 2.5.0
- *
- * @param string|object $screen Screen identifier
- * @param string $context box context
- * @param mixed $object gets passed to the box callback function as first parameter
+ * @param string|object $screen Screen identifier.
+ * @param string        $context box context.
+ * @param mixed         $object gets passed to the box callback function as first parameter.
  * @return int number of meta_boxes
  */
 function cmb_do_meta_boxes( $screen, $context, $object ) {
@@ -48,8 +50,8 @@ function cmb_do_meta_boxes( $screen, $context, $object ) {
 	$i = 0;
 
 	do {
-		// Grab the ones the user has manually sorted. Pull them out of their previous context/priority and into the one the user chose
-
+		// Grab the ones the user has manually sorted. Pull them out of their previous context/priority
+		// and into the one the user chose.
 		if ( ! $already_sorted && $sorted = get_user_option( "meta-box-order_$page" ) )
 			foreach ( $sorted as $box_context => $ids )
 				foreach ( explode(',', $ids ) as $id )

--- a/fields-anywhere.php
+++ b/fields-anywhere.php
@@ -11,7 +11,7 @@
 /**
  * Draw the meta boxes in places other than the post edit screen.
  *
- * @param string|object $screen Screen identifier.
+ * @param string|object $pages Post type or screen identifier.
  * @param string        $context Optional. box context.
  * @param mixed         $object gets passed to the box callback function as first parameter.
  */


### PR DESCRIPTION
Docblocks and inline documentation were sorely missing and I wanted to put us at a better place in respect to new developers hopping on board. It's also really easy to find bugs in logic when writing documentation.

This PR is a very basic documentation implementation - I added basic notes and docblocks and fixed all PHPCS complaints but didn't want to go much deeper as this PR is already getting to be a monster one to review. This should probably be picked up again in a future release separately.

There are no code or logic changes here, only documentation.

Partially addresses #361

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [x] Added any new PHPUnit tests
 - [x] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install
