### PR TITLE
Strengthening Base Field Unit Tests

### DIFF
--- a/tests/testDateField.php
+++ b/tests/testDateField.php
@@ -35,8 +35,8 @@ class DateFieldsAssetsTestCase extends WP_UnitTestCase {
 		$this->assertContains( '/js/field.datetime.js', $scripts_output );
 		$this->assertContains( '/js/cmb.js', $scripts_output );
 		if ( version_compare( $wp_version, '4.1', '>=' ) ) {
-			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/core.js', $scripts_output );
-			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/datepicker.js', $scripts_output );
+			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/core.min.js', $scripts_output );
+			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/datepicker.min.js', $scripts_output );
 		} else {
 			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/jquery.ui.core.min.js', $scripts_output );
 			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/jquery.ui.datepicker.min.js', $scripts_output );

--- a/tests/testDateField.php
+++ b/tests/testDateField.php
@@ -35,8 +35,8 @@ class DateFieldsAssetsTestCase extends WP_UnitTestCase {
 		$this->assertContains( '/js/field.datetime.js', $scripts_output );
 		$this->assertContains( '/js/cmb.js', $scripts_output );
 		if ( version_compare( $wp_version, '4.1', '>=' ) ) {
-			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/core.min.js', $scripts_output );
-			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/datepicker.min.js', $scripts_output );
+			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/core.js', $scripts_output );
+			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/datepicker.js', $scripts_output );
 		} else {
 			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/jquery.ui.core.min.js', $scripts_output );
 			$this->assertContains( site_url() . '/wp-includes/js/jquery/ui/jquery.ui.datepicker.min.js', $scripts_output );

--- a/tests/testField.php
+++ b/tests/testField.php
@@ -138,7 +138,7 @@ class FieldTestCase extends WP_UnitTestCase {
 		}
 
 		// Test empty output
-		$this->expectOutputRegex( '/(value=\"1\")/s' );
+		$this->expectOutputRegex( '/(type=\"text\".*?id=\"foo-cmb-field-0\".*?value=\"1\")/s' );
 
 		// Trigger output.
 		$field->html();
@@ -155,7 +155,7 @@ class FieldTestCase extends WP_UnitTestCase {
 
 		$field->save( $this->post->ID, $field_value );
 
-		$this->expectOutputRegex( '/(value=\"one\")/s' );
+		$this->expectOutputRegex( '/(type=\"text\".*?id=\"foo-cmb-field-0\".*?value=\"one\")/s' );
 
 		// Trigger output.
 		$field->html();

--- a/tests/testField.php
+++ b/tests/testField.php
@@ -34,39 +34,49 @@ class FieldTestCase extends WP_UnitTestCase {
 		$field = new CMB_Text_Field( 'foo', 'Title', array( 1 ) );
 		$this->assertEquals( $field->get_values(), array( 1 ) );
 
-		// // Multiple Values - eg repeatable.
+		// Single, saved value.
+		$field_value  = array( 'one' );
+		$field->save( $this->post->ID, $field_value );
+		$this->assertEquals( $field->get_values(), $field_value );
+
+		// Multiple Values - eg repeatable.
 		$field = new CMB_Text_Field( 'foo', 'Title', array( 1, 2 ), array( 'repeatable' => true ) );
 		$this->assertEquals( $field->get_values(), array( 1, 2 ) );
+
+		// Multiple, saved values.
+		$repeat_value = array( 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'zero' );
+		$field->save( $this->post->ID, $repeat_value );
+		$this->assertEquals( $field->get_values(), $repeat_value );
 
 	}
 
 	function testSaveValues() {
 
-		$field = new CMB_Text_Field( 'foo', 'Title', array( 1 ) );
+		$field        = new CMB_Text_Field( 'foo', 'Title', array( 1 ) );
+		$field_value  = array( 'one' );
 
 		if ( ! $this->post )
 			$this->markTestSkipped( 'Post not found' );
 
-		$field->save( $this->post->ID, array( 1 ) );
+		$field->save( $this->post->ID, $field_value );
 
-		$meta = get_post_meta( $this->post->ID, 'foo', false );
-
-		$this->assertEquals( $meta, array( 1 ) );
+		// Verify single value is properly saved.
+		$this->assertEquals( get_post_meta( $this->post->ID, 'foo', false ), $field_value );
 
 	}
 
 	function testSaveValuesOnRepeatable() {
 
-		$field = new CMB_Text_Field( 'foo', 'Title', array( 1, 2 ), array( 'repeatable' => true ) );
+		$field        = new CMB_Text_Field( 'foo', 'Title', array( 1, 2 ), array( 'repeatable' => true ) );
+		$repeat_value = array( 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'zero' );
 
 		if ( ! $this->post )
 			$this->markTestSkipped( 'Post not found' );
 
-		$field->save( $this->post->ID, array( 1, 2 ) );
+		$field->save( $this->post->ID, $repeat_value );
 
-		$meta = get_post_meta( $this->post->ID, 'foo', false );
-
-		$this->assertEquals( $meta, array( 1, 2 ) );
+		// Test that the repeatable field is saved properly.
+		$this->assertEquals( get_post_meta( $this->post->ID, 'foo', false ), $repeat_value );
 
 	}
 
@@ -118,6 +128,37 @@ class FieldTestCase extends WP_UnitTestCase {
 		$id_attr = $field->get_the_name_attr();
 		$this->assertEquals( $id_attr, 'foo[cmb-field-12]' );
 
+	}
+
+	function testEmptyFieldOutput() {
+		$field = new CMB_Text_Field( 'foo', 'Title', array( 1 ) );
+
+		if ( ! $this->post ) {
+			$this->markTestSkipped( 'Post not found' );
+		}
+
+		// Test empty output
+		$this->expectOutputRegex( '/(value=\"1\")/s' );
+
+		// Trigger output.
+		$field->html();
+
+	}
+
+	function testSavedFieldOutput() {
+		$field        = new CMB_Text_Field( 'foo', 'Title', array( 1 ) );
+		$field_value  = array( 'one' );
+
+		if ( ! $this->post ) {
+			$this->markTestSkipped( 'Post not found' );
+		}
+
+		$field->save( $this->post->ID, $field_value );
+
+		$this->expectOutputRegex( '/(value=\"one\")/s' );
+
+		// Trigger output.
+		$field->html();
 	}
 
 }


### PR DESCRIPTION
Due to a previously failed fix for repeatable field values I wanted to strengthen the tests for basic fields, especially repeatable values.

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [x] Added any new PHPUnit tests
 - [x] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install
