### PR TITLE
Fix missing class checks

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1843,7 +1843,7 @@ class CMB_Group_Field extends CMB_Field {
 
 				$class = _cmb_field_class_for_type( $f['type'] );
 
-				if ( $class && class_exists( $class ) ) {
+				if ( ! empty( $class ) && class_exists( $class ) ) {
 					$this->add_field( new $class( $f['id'], $f['name'], array(), $f ) );
 				}
 			}
@@ -1878,7 +1878,7 @@ class CMB_Group_Field extends CMB_Field {
 
 		foreach ( $this->args['fields'] as $f ) {
 			$class = _cmb_field_class_for_type( $f['type'] );
-			if ( $class && class_exists( $class ) ) {
+			if ( ! empty( $class ) && class_exists( $class ) ) {
 				$field = new $class( '', '', array(), $f );
 				$field->enqueue_scripts();
 			}
@@ -1897,7 +1897,7 @@ class CMB_Group_Field extends CMB_Field {
 
 		foreach ( $this->args['fields'] as $f ) {
 			$class = _cmb_field_class_for_type( $f['type'] );
-			if ( $class && class_exists( $class ) ) {
+			if ( ! empty( $class ) && class_exists( $class ) ) {
 				$field = new $class( '', '', array(), $f );
 				$field->enqueue_styles();
 			}

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1842,7 +1842,10 @@ class CMB_Group_Field extends CMB_Field {
 			foreach ( $this->args['fields'] as $f ) {
 
 				$class = _cmb_field_class_for_type( $f['type'] );
-				$this->add_field( new $class( $f['id'], $f['name'], array(), $f ) );
+
+				if ( $class && class_exists( $class ) ) {
+					$this->add_field( new $class( $f['id'], $f['name'], array(), $f ) );
+				}
 
 			}
 		}
@@ -1876,8 +1879,10 @@ class CMB_Group_Field extends CMB_Field {
 
 		foreach ( $this->args['fields'] as $f ) {
 			$class = _cmb_field_class_for_type( $f['type'] );
-			$field = new $class( '', '', array(), $f );
-			$field->enqueue_scripts();
+			if ( $class && class_exists( $class ) ) {
+				$field = new $class( '', '', array(), $f );
+				$field->enqueue_scripts();
+			}
 		}
 
 	}
@@ -1893,8 +1898,10 @@ class CMB_Group_Field extends CMB_Field {
 
 		foreach ( $this->args['fields'] as $f ) {
 			$class = _cmb_field_class_for_type( $f['type'] );
-			$field = new $class( '', '', array(), $f );
-			$field->enqueue_styles();
+			if ( $class && class_exists( $class ) ) {
+				$field = new $class( '', '', array(), $f );
+				$field->enqueue_styles();
+			}
 		}
 
 	}

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1846,7 +1846,6 @@ class CMB_Group_Field extends CMB_Field {
 				if ( $class && class_exists( $class ) ) {
 					$this->add_field( new $class( $f['id'], $f['name'], array(), $f ) );
 				}
-
 			}
 		}
 


### PR DESCRIPTION
We were missing class checks in the group field that could potentially cause a 500 given a wrong or misspelled type name. This resolves that issue with some simple checks.

Resolves #377

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [x] Added any new PHPUnit tests
 - [x] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install