### PR TITLE
Fix example functions file

### DIFF
--- a/example-functions.php
+++ b/example-functions.php
@@ -23,7 +23,7 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		 * Basic Text Field.
 		 */
 		array(
-			'id'   => 'field-1',
+			'id'   => 'field-text',
 			'name' => 'Text input field',
 			'type' => 'text',
 		),
@@ -85,145 +85,34 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		 * Small Text Field.
 		 */
 		array(
-			'id'   => 'field-3',
+			'id'   => 'field-small-text',
 			'name' => 'Small text input field',
 			'type' => 'text_small',
-		),
-
-		/*
-		 * URL Field.
-		 */
-		array(
-			'id'   => 'field-4',
-			'name' => 'URL field',
-			'type' => 'url',
-		),
-
-		/*
-		 * Radio Input Field.
-		 */
-		array(
-			'id'      => 'field-5',
-			'name'    => 'Radio input field',
-			'type'    => 'radio',
-			'options' => array( // Options for individual radio inputs.
-				'Option 1',
-				'Option 2',
-			),
 		),
 
 		/*
 		 * Single Checkbox Field.
 		 */
 		array(
-			'id'    => 'field-6',
+			'id'    => 'field-checkbox',
 			'name' => 'Checkbox field',
 			'type' => 'checkbox',
 		),
 
 		/*
-		 * WYSIWYG (What You See is What You Get) TinyMCE Field.
+		 * Colorpicker Field.
 		 */
 		array(
-			'id'         => 'field-7',
-			'name'       => 'WYSIWYG field',
-			'type'       => 'wysiwyg',
-			'options'    => array( // Options to pass into TinyMCE instance.
-				'editor_height' => '100',
-			),
-		),
-
-		/*
-		 * Textarea Field.
-		 */
-		array(
-			'id'   => 'field-8',
-			'name' => 'Textarea field',
-			'type' => 'textarea',
-		),
-
-		/*
-		 * Textarea Code Field.
-		 */
-		array(
-			'id'   => 'field-9',
-			'name' => 'Code textarea field',
-			'type' => 'textarea_code',
-		),
-
-		/*
-		 * File Upload Field.
-		 */
-		array(
-			'id'           => 'field-10',
-			'name'         => 'File field',
-			'type'         => 'file',
-			'library-type' => array( // Optional. Type of media allowed [ 'audio', 'video', 'text', 'application' ].
-				'video',
-			),
-		),
-
-		/*
-		 * Image Upload Field.
-		 */
-		array(
-			'id'         => 'field-11',
-			'name'       => 'Image upload field',
-			'type'       => 'image',
-			'repeatable' => true,
-			'size'       => 'thumbnail', // Optional. Registered media size to display.
-			'show_size'  => true,        // Optional. Whether to show the image dimensions underneath image itself.
-		),
-
-		/*
-		 * Select Field.
-		 */
-		array(
-			'id'              => 'field-12',
-			'name'            => 'Select field',
-			'type'            => 'select',
-			'options'         => array(
-				'option-1' => 'Option 1',
-				'option-2' => 'Option 2',
-				'option-3' => 'Option 3',
-			),
-			'allow_none'      => true,    // Optional. Allow a user to not select any options.
-			'multiple'        => true,    // Optional. Allow multi-select.
-			'select2_options' => array(), // Optional. Array of options to pass to Select2.
-		),
-
-		/*
-		 * Select for Taxonomies Field.
-		 */
-		array(
-			'id'         => 'field-13',
-			'name'       => 'Select taxonomy field',
-			'type'       => 'taxonomy_select',
-			'taxonomy'   => 'category', // Required. Name of taxonomy to pull options from.
-			'hide_empty' => false,      // Optional. Whether to hide empty terms or not.
-			'multiple'   => true,       // Optional. Allow multi-select.
-
-		),
-
-		/*
-		 * Select for Posts Field.
-		 */
-		array(
-			'id'       => 'field-14',
-			'name'     => 'Post select field',
-			'type'     => 'post_select',
-			'use_ajax' => false,  // Optional. Use AJAX for instant results or load on pageload.
-			'multiple' => true,   // Optional. Allow multi-select.
-			'query'    => array(  // Optional. WP_Query options to pass through.
-				'cat' => 1,
-			),
+			'id'   => 'field-colorpicker',
+			'name' => 'Color',
+			'type' => 'colorpicker',
 		),
 
 		/*
 		 * Basic Date Field.
 		 */
 		array(
-			'id'   => 'field-18',
+			'id'   => 'field-date',
 			'name' => 'Date input field',
 			'type' => 'date',
 		),
@@ -232,7 +121,7 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		 * Basic Time Field.
 		 */
 		array(
-			'id'    => 'field-19',
+			'id'    => 'field-time',
 			'name' => 'Time input field',
 			'type' => 'time',
 		),
@@ -241,7 +130,7 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		 * Date UNIX Field.
 		 */
 		array(
-			'id'   => 'field-20',
+			'id'   => 'field-date-unix',
 			'name' => 'Date (unix) input field',
 			'type' => 'date_unix',
 		),
@@ -250,25 +139,16 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		 * Date & Time UNIX Field.
 		 */
 		array(
-			'id'   => 'field-21',
+			'id'   => 'field-datetime-unix',
 			'name' => 'Date & Time (unix) input field',
 			'type' => 'datetime_unix',
-		),
-
-		/*
-		 * Colorpicker Field.
-		 */
-		array(
-			'id'   => 'field-22',
-			'name' => 'Color',
-			'type' => 'colorpicker',
 		),
 
 		/*
 		 * Google Map Field.
 		 */
 		array(
-			'id'                          => 'field-23',
+			'id'                          => 'field-gmap',
 			'name'                        => 'Location',
 			'type'                        => 'gmap',
 
@@ -298,12 +178,132 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		),
 
 		/*
+		 * Radio Input Field.
+		 */
+		array(
+			'id'      => 'field-radio',
+			'name'    => 'Radio input field',
+			'type'    => 'radio',
+			'options' => array( // Options for individual radio inputs.
+				'Option 1',
+				'Option 2',
+			),
+		),
+
+		/*
+		 * File Upload Field.
+		 */
+		array(
+			'id'           => 'field-file',
+			'name'         => 'File field',
+			'type'         => 'file',
+			'library-type' => array( // Optional. Type of media allowed [ 'audio', 'video', 'text', 'application' ].
+				'video',
+			),
+		),
+
+		/*
+		 * File Image Upload Field.
+		 */
+		array(
+			'id'         => 'field-image',
+			'name'       => 'Image upload field',
+			'type'       => 'image',
+			'repeatable' => true,
+			'size'       => 'thumbnail', // Optional. Registered media size to display.
+			'show_size'  => true,        // Optional. Whether to show the image dimensions underneath image itself.
+		),
+
+		/*
+		 * Select Field.
+		 */
+		array(
+			'id'              => 'field-select',
+			'name'            => 'Select field',
+			'type'            => 'select',
+			'options'         => array(
+				'option-1' => 'Option 1',
+				'option-2' => 'Option 2',
+				'option-3' => 'Option 3',
+			),
+			'allow_none'      => true,    // Optional. Allow a user to not select any options.
+			'multiple'        => true,    // Optional. Allow multi-select.
+			'select2_options' => array(), // Optional. Array of options to pass to Select2.
+		),
+
+		/*
+		 * Select for Taxonomies Field.
+		 */
+		array(
+			'id'         => 'field-select-for-taxonomies',
+			'name'       => 'Select taxonomy field',
+			'type'       => 'taxonomy_select',
+			'taxonomy'   => 'category', // Required. Name of taxonomy to pull options from.
+			'hide_empty' => false,      // Optional. Whether to hide empty terms or not.
+			'multiple'   => true,       // Optional. Allow multi-select.
+
+		),
+
+		/*
+		 * Select for Posts Field.
+		 */
+		array(
+			'id'       => 'field-select-for-posts',
+			'name'     => 'Post select field',
+			'type'     => 'post_select',
+			'use_ajax' => false,  // Optional. Use AJAX for instant results or load on pageload.
+			'multiple' => true,   // Optional. Allow multi-select.
+			'query'    => array(  // Optional. WP_Query options to pass through.
+				'cat' => 1,
+			),
+		),
+
+		/*
 		 * Plain Title Field.
 		 */
 		array(
-			'id'   => 'field-24',
+			'id'   => 'field-title',
 			'name' => 'Title Field',
 			'type' => 'title',
+		),
+
+		/*
+		 * Textarea Field.
+		 */
+		array(
+			'id'   => 'field-textarea',
+			'name' => 'Textarea field',
+			'type' => 'textarea',
+		),
+
+		/*
+		 * Textarea Code Field.
+		 */
+		array(
+			'id'   => 'field-textarea-code',
+			'name' => 'Code textarea field',
+			'type' => 'textarea_code',
+		),
+
+		/*
+		 * WYSIWYG (What You See is What You Get) TinyMCE Field.
+		 */
+		array(
+			'id'         => 'field-wysiwyg',
+			'name'       => 'WYSIWYG field',
+			'type'       => 'wysiwyg',
+			'options'    => array( // Options to pass into TinyMCE instance.
+				'editor_height' => '100',
+			),
+		),
+
+		/*
+		 * URL Field.
+		 */
+		array(
+			'id'   => 'field-url',
+			'name' => 'URL field',
+			'type' => 'url',
 		),
 
 	);
@@ -323,21 +323,21 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 	$groups_and_cols = array(
 
 		array(
-			'id' => 'gac-1',
+			'id'   => 'gac-1',
 			'name' => 'Text input field',
 			'type' => 'text',
 			'cols' => 4,
 		),
 
 		array(
-			'id' => 'gac-2',
+			'id'   => 'gac-2',
 			'name' => 'Text input field',
 			'type' => 'text',
 			'cols' => 4,
 		),
 
 		array(
-			'id' => 'gac-3',
+			'id'   => 'gac-3',
 			'name' => 'Text input field',
 			'type' => 'text',
 			'cols' => 4,

--- a/example-functions.php
+++ b/example-functions.php
@@ -17,48 +17,300 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 	/**
 	 * Example of all available fields.
 	 */
-
 	$fields = array(
 
-		array( 'id' => 'field-1',  'name' => 'Text input field', 'type' => 'text' ),
-		array( 'id' => 'field-2', 'name' => 'Read-only text input field', 'type' => 'text', 'readonly' => true, 'default' => 'READ ONLY' ),
-		array( 'id' => 'field-3', 'name' => 'Repeatable text input field', 'type' => 'text', 'desc' => 'Add up to 5 fields.', 'repeatable' => true, 'repeatable_max' => 5, 'sortable' => true ),
+		/*
+		 * Basic Text Field.
+		 */
+		array(
+			'id'   => 'field-1',
+			'name' => 'Text input field',
+			'type' => 'text',
+		),
 
-		array( 'id' => 'field-4',  'name' => 'Small text input field', 'type' => 'text_small' ),
-		array( 'id' => 'field-5',  'name' => 'URL field', 'type' => 'url' ),
+		/*
+		 * Text Field with all options.
+		 */
+		array(
+			// Required. ID of CMB value to be inserted into database.
+			'id'              => 'field-2',
 
-		array( 'id' => 'field-6',  'name' => 'Radio input field', 'type' => 'radio', 'options' => array( 'Option 1', 'Option 2' ) ),
-		array( 'id' => 'field-7',  'name' => 'Checkbox field', 'type' => 'checkbox' ),
+			// Required.Type of field to call.
+			'type'            => 'text',
 
-		array( 'id' => 'field-8',  'name' => 'WYSIWYG field', 'type' => 'wysiwyg', 'options' => array( 'editor_height' => '100' ), 'repeatable' => true, 'sortable' => true ),
+			// Optional. Title that will show above field.
+			'name'            => __( 'Name', 'cmb' ),
 
-		array( 'id' => 'field-9',  'name' => 'Textarea field', 'type' => 'textarea' ),
-		array( 'id' => 'field-10',  'name' => 'Code textarea field', 'type' => 'textarea_code' ),
+			// Optional. Contextual information. Will display underneath field.
+			'desc'            => __( 'Repeatable', 'cmb' ),
 
-		array( 'id' => 'field-11', 'name' => 'File field', 'type' => 'file', 'file_type' => 'image', 'repeatable' => 1, 'sortable' => 1 ),
-		array( 'id' => 'field-12', 'name' => 'Image upload field', 'type' => 'image', 'repeatable' => true, 'show_size' => true ),
+			// Optional. Whether field should be repeatable.
+			'repeatable'      => true,
 
-		array( 'id' => 'field-13', 'name' => 'Select field', 'type' => 'select', 'options' => array( 'option-1' => 'Option 1', 'option-2' => 'Option 2', 'option-3' => 'Option 3' ), 'allow_none' => true, 'sortable' => true, 'repeatable' => true ),
-		array( 'id' => 'field-14', 'name' => 'Select field', 'type' => 'select', 'options' => array( 'option-1' => 'Option 1', 'option-2' => 'Option 2', 'option-3' => 'Option 3' ), 'multiple' => true ),
-		array( 'id' => 'field-15', 'name' => 'Select taxonomy field', 'type' => 'taxonomy_select',  'taxonomy' => 'category' ),
-		array( 'id' => 'field-15b', 'name' => 'Select taxonomy field', 'type' => 'taxonomy_select',  'taxonomy' => 'category',  'multiple' => true ),
-		array( 'id' => 'field-16', 'name' => 'Post select field', 'type' => 'post_select', 'use_ajax' => false, 'query' => array( 'cat' => 1 ) ),
-		array( 'id' => 'field-17', 'name' => 'Post select field (AJAX)', 'type' => 'post_select', 'use_ajax' => true ),
-		array( 'id' => 'field-17b', 'name' => 'Post select field (AJAX)', 'type' => 'post_select', 'use_ajax' => true, 'query' => array( 'posts_per_page' => 8 ), 'multiple' => true ),
+			// Optional. Maximum number of repetitions allowed.
+			'repeatable_max'  => 5,
 
-		array( 'id' => 'field-18', 'name' => 'Date input field', 'type' => 'date' ),
-		array( 'id' => 'field-19', 'name' => 'Time input field', 'type' => 'time' ),
-		array( 'id' => 'field-20', 'name' => 'Date (unix) input field', 'type' => 'date_unix' ),
-		array( 'id' => 'field-21', 'name' => 'Date & Time (unix) input field', 'type' => 'datetime_unix' ),
+			// Optional. Whether repeated instances should be sortable.
+			'sortable'        => true,
 
-		array( 'id' => 'field-22', 'name' => 'Color', 'type' => 'colorpicker' ),
+			// Optional. Don't display field label if set to false.
+			'show_label'      => false,
 
-		array( 'id' => 'field-23', 'name' => 'Location', 'type' => 'gmap', 'google_api_key' => '{CUSTOM_KEY}' ),
+			// Optional. Make a filed uneditable by user but value will still be saved.
+			'readonly'        => false,
 
-		array( 'id' => 'field-24', 'name' => 'Title Field', 'type' => 'title' ),
+			// Optional. Make field uneditable by user and value will NOT be saved.
+			'disabled'        => false,
+
+			// Optional. Default value for new posts.
+			'default'         => '',
+
+			// Optional. Number of columns field should take up out of 12.
+			'cols'            => '12',
+
+			// Optional. Add custom styles to field.
+			'style'           => '',
+
+			// Optional. Add custom CSS classes to field.
+			'class'           => '',
+
+			// Optional. Custom data callback for field.
+			'data_delegate'   => null,
+
+			// Optional. Custom save method for field.
+			'save_callback'   => null,
+		),
+
+		/*
+		 * Small Text Field.
+		 */
+		array(
+			'id'   => 'field-3',
+			'name' => 'Small text input field',
+			'type' => 'text_small',
+		),
+
+		/*
+		 * URL Field.
+		 */
+		array(
+			'id'   => 'field-4',
+			'name' => 'URL field',
+			'type' => 'url',
+		),
+
+		/*
+		 * Radio Input Field.
+		 */
+		array(
+			'id'      => 'field-5',
+			'name'    => 'Radio input field',
+			'type'    => 'radio',
+			'options' => array( // Options for individual radio inputs.
+				'Option 1',
+				'Option 2',
+			),
+		),
+
+		/*
+		 * Single Checkbox Field.
+		 */
+		array(
+			'id'    => 'field-6',
+			'name' => 'Checkbox field',
+			'type' => 'checkbox',
+		),
+
+		/*
+		 * WYSIWYG (What You See is What You Get) TinyMCE Field.
+		 */
+		array(
+			'id'         => 'field-7',
+			'name'       => 'WYSIWYG field',
+			'type'       => 'wysiwyg',
+			'options'    => array( // Options to pass into TinyMCE instance.
+				'editor_height' => '100',
+			),
+		),
+
+		/*
+		 * Textarea Field.
+		 */
+		array(
+			'id'   => 'field-8',
+			'name' => 'Textarea field',
+			'type' => 'textarea',
+		),
+
+		/*
+		 * Textarea Code Field.
+		 */
+		array(
+			'id'   => 'field-9',
+			'name' => 'Code textarea field',
+			'type' => 'textarea_code',
+		),
+
+		/*
+		 * File Upload Field.
+		 */
+		array(
+			'id'           => 'field-10',
+			'name'         => 'File field',
+			'type'         => 'file',
+			'library-type' => array( // Optional. Type of media allowed [ 'audio', 'video', 'text', 'application' ].
+				'video',
+			),
+		),
+
+		/*
+		 * Image Upload Field.
+		 */
+		array(
+			'id'         => 'field-11',
+			'name'       => 'Image upload field',
+			'type'       => 'image',
+			'repeatable' => true,
+			'size'       => 'thumbnail', // Optional. Registered media size to display.
+			'show_size'  => true,        // Optional. Whether to show the image dimensions underneath image itself.
+		),
+
+		/*
+		 * Select Field.
+		 */
+		array(
+			'id'              => 'field-12',
+			'name'            => 'Select field',
+			'type'            => 'select',
+			'options'         => array(
+				'option-1' => 'Option 1',
+				'option-2' => 'Option 2',
+				'option-3' => 'Option 3',
+			),
+			'allow_none'      => true,    // Optional. Allow a user to not select any options.
+			'multiple'        => true,    // Optional. Allow multi-select.
+			'select2_options' => array(), // Optional. Array of options to pass to Select2.
+		),
+
+		/*
+		 * Select for Taxonomies Field.
+		 */
+		array(
+			'id'         => 'field-13',
+			'name'       => 'Select taxonomy field',
+			'type'       => 'taxonomy_select',
+			'taxonomy'   => 'category', // Required. Name of taxonomy to pull options from.
+			'hide_empty' => false,      // Optional. Whether to hide empty terms or not.
+			'multiple'   => true,       // Optional. Allow multi-select.
+
+		),
+
+		/*
+		 * Select for Posts Field.
+		 */
+		array(
+			'id'       => 'field-14',
+			'name'     => 'Post select field',
+			'type'     => 'post_select',
+			'use_ajax' => false,  // Optional. Use AJAX for instant results or load on pageload.
+			'multiple' => true,   // Optional. Allow multi-select.
+			'query'    => array(  // Optional. WP_Query options to pass through.
+				'cat' => 1,
+			),
+		),
+
+		/*
+		 * Basic Date Field.
+		 */
+		array(
+			'id'   => 'field-18',
+			'name' => 'Date input field',
+			'type' => 'date',
+		),
+
+		/*
+		 * Basic Time Field.
+		 */
+		array(
+			'id'    => 'field-19',
+			'name' => 'Time input field',
+			'type' => 'time',
+		),
+
+		/*
+		 * Date UNIX Field.
+		 */
+		array(
+			'id'   => 'field-20',
+			'name' => 'Date (unix) input field',
+			'type' => 'date_unix',
+		),
+
+		/*
+		 * Date & Time UNIX Field.
+		 */
+		array(
+			'id'   => 'field-21',
+			'name' => 'Date & Time (unix) input field',
+			'type' => 'datetime_unix',
+		),
+
+		/*
+		 * Colorpicker Field.
+		 */
+		array(
+			'id'   => 'field-22',
+			'name' => 'Color',
+			'type' => 'colorpicker',
+		),
+
+		/*
+		 * Google Map Field.
+		 */
+		array(
+			'id'                          => 'field-23',
+			'name'                        => 'Location',
+			'type'                        => 'gmap',
+
+			// Required. Pass a Google Maps API key. Alternatively, set with CMB_GAPI_KEY constant.
+			'google_api_key'              => '{CUSTOM_KEY}',
+
+			// Optional. Width of address input + map display.
+			'field_width'                 => '100%',
+
+			// Optional. Static height of address input + map display.
+			'field_height'                => '250px',
+
+			// Optional Default latitude for map to display on page load.
+			'default_lat'                 => '51.5073509',
+
+			// Optional. Default longitude for map to display on page load.
+			'default_long'                => '-0.12775829999998223',
+
+			// Optional. Default zoom for map to display on page load. 1 = Whole world, 20 = Individual buildings
+			'default_zoom'                => '8',
+
+			// Optional. Override Marker title text.
+			'string-marker-title'         => esc_html__( 'Drag to set the exact location', 'cmb' ),
+
+			// Optional. Override maps error message.
+			'string-gmaps-api-not-loaded' => esc_html__( 'Google Maps API not loaded.', 'cmb' ),
+		),
+
+		/*
+		 * Plain Title Field.
+		 */
+		array(
+			'id'   => 'field-24',
+			'name' => 'Title Field',
+			'type' => 'title',
+		),
 
 	);
 
+	/**
+	 * Metabox instantiation.
+	 */
 	$meta_boxes[] = array(
 		'title' => 'CMB Test - all fields',
 		'pages' => 'post',
@@ -68,35 +320,69 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 	/**
 	 * Examples of Groups and Columns.
 	 */
-
 	$groups_and_cols = array(
-		array( 'id' => 'gac-1',  'name' => 'Text input field', 'type' => 'text', 'cols' => 4 ),
-		array( 'id' => 'gac-2',  'name' => 'Text input field', 'type' => 'text', 'cols' => 4 ),
-		array( 'id' => 'gac-3',  'name' => 'Text input field', 'type' => 'text', 'cols' => 4 ),
+
+		array(
+			'id' => 'gac-1',
+			'name' => 'Text input field',
+			'type' => 'text',
+			'cols' => 4,
+		),
+
+		array(
+			'id' => 'gac-2',
+			'name' => 'Text input field',
+			'type' => 'text',
+			'cols' => 4,
+		),
+
+		array(
+			'id' => 'gac-3',
+			'name' => 'Text input field',
+			'type' => 'text',
+			'cols' => 4,
+		),
+
+		/**
+		 * Group within a Group.
+		 */
 		array(
 			'id'     => 'gac-4',
 			'name'   => 'Group (4 columns)',
 			'type'   => 'group',
 			'cols'   => 4,
 			'fields' => array(
-				array( 'id' => 'gac-4-f-1',  'name' => 'Textarea field', 'type' => 'textarea' ),
+				array(
+					'id' => 'gac-4-f-1',
+					'name' => 'Textarea field',
+					'type' => 'textarea',
+				),
 			),
 		),
+
 		array(
 			'id'     => 'gac-5',
 			'name'   => 'Group (8 columns)',
 			'type'   => 'group',
 			'cols'   => 8,
 			'fields' => array(
-				array( 'id' => 'gac-4-f-1',  'name' => 'Text input field', 'type' => 'text' ),
-				array( 'id' => 'gac-4-f-2',  'name' => 'Text input field', 'type' => 'text' ),
+				array(
+					'id' => 'gac-4-f-1',
+					'name' => 'Text input field',
+					'type' => 'text',
+				),
+				array(
+					'id' => 'gac-4-f-2',
+					'name' => 'Text input field',
+					'type' => 'text',
+				),
 			),
 		),
 	);
 
 	$meta_boxes[] = array(
-		'title' => 'Groups and Columns',
-		'pages' => 'post',
+		'title'  => 'Groups and Columns',
+		'pages'  => 'post',
 		'fields' => $groups_and_cols,
 	);
 
@@ -115,13 +401,13 @@ function cmb_sample_metaboxes( array $meta_boxes ) {
 		'pages' => 'post',
 		'fields' => array(
 			array(
-				'id' => 'gp',
-				'name' => 'My Repeatable Group',
-				'type' => 'group',
+				'id'         => 'gp',
+				'name'       => 'My Repeatable Group',
+				'type'       => 'group',
 				'repeatable' => true,
-				'sortable' => true,
-				'fields' => $group_fields,
-				'desc' => 'This is the group description.',
+				'sortable'   => true,
+				'fields'     => $group_fields,
+				'desc'       => 'This is the group description.',
 			),
 		),
 	);


### PR DESCRIPTION
The example functions file was a bit of a mess and really hard to read, not to mention incomplete as far as available functions. Spent a little bit of time cleaning this sucker up so that people can really reference and read it.

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
