### PR TITLE
Fixed sortable logic for non-repeatable fields

### DIFF
--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -388,7 +388,7 @@ class CMB_Meta_Box {
 					$classes[] = 'repeatable';
 				}
 
-				if ( ! empty( $field->args['sortable'] ) ) {
+				if ( ! empty( $field->args['sortable'] ) && ! empty( $field->args['repeatable'] ) ) {
 					$classes[] = 'cmb-sortable';
 				}
 

--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -390,6 +390,9 @@ class CMB_Meta_Box {
 
 				if ( ! empty( $field->args['sortable'] ) && ! empty( $field->args['repeatable'] ) ) {
 					$classes[] = 'cmb-sortable';
+				} elseif ( ! empty( $field->args['sortable'] ) && empty( $field->args['repeatable'] ) ) {
+					// Throw an error if calling the wrong combination of sortable and repeatable.
+					_doing_it_wrong( 'cmb_meta_boxes', __( 'Calling sortable on a non-repeatable field. A field cannot be sortable without being repeatable.', 'cmb' ), 4.7 );
 				}
 
 				// Assign extra class for has label or has no label.

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -105,7 +105,7 @@ abstract class CMB_Field {
 	 */
 	public function enqueue_scripts() {
 
-		if ( isset( $this->args['sortable'] ) && $this->args['sortable'] ) {
+		if ( isset( $this->args['sortable'] ) && $this->args['sortable'] && $this->args['repeatable'] ) {
 			wp_enqueue_script( 'jquery-ui-sortable' );
 		}
 


### PR DESCRIPTION
Previously, you could assign `sortable` to a static field but if a field isn't repeatable it can only have one instance of itself - making sortable useless. The fix was to tie sortable logic into the `repeatable` option so that sortable cannot be triggered unless repeatable also is.

Resolves #342

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [x] Added any new PHPUnit tests
 - [x] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install