### PR TITLE
Remove unnecessary WP builds to speed up the total build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,20 @@ matrix:
     - php: hhvm
   fast_finish: true
   exclude:
-  # Only test latest version of WP with HHVM
+    # We really only need to verify that each PHP/WP combination works generally, not that multisite works between them
+    - php: 5.3
+      env: WP_VERSION=3.8 WP_MULTISITE=1
+    - php: 5.3
+      env: WP_VERSION=latest WP_MULTISITE=1
+    - php: 5.4
+      env: WP_VERSION=3.8 WP_MULTISITE=1
+    - php: 5.4
+      env: WP_VERSION=latest WP_MULTISITE=1
+    - php: 5.5
+      env: WP_VERSION=3.8 WP_MULTISITE=1
+    - php: 5.5
+      env: WP_VERSION=latest WP_MULTISITE=1
+    # Only test latest version of WP with HHVM
     - php: hhvm
       env: WP_VERSION=3.8 WP_MULTISITE=0
     - php: hhvm


### PR DESCRIPTION
Travis currently takes more than 11 minutes to do a build which is driving me crazy. I've removed the PR checks as each push is run anyways and now removing 6 of the 20 individual environments that are run on each check. 

This should take the total build time down to about 3 minutes and drastically reduce the stacking effect that we get when pushing several things in a short time period.