### PR TITLE
Fixed escaping in WYSIWYG field type - props @ocean90

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1279,7 +1279,7 @@ class CMB_wysiwyg extends CMB_Field {
 			<script>
 				if ( 'undefined' === typeof( cmb_wysiwyg_editors ) )
 					var cmb_wysiwyg_editors = {};
-				cmb_wysiwyg_editors.<?php echo esc_js( $field_id ); ?> = '<?php echo esc_js( $editor ); ?>';
+				cmb_wysiwyg_editors.<?php echo esc_js( $field_id ); ?> = <?php echo json_encode( $editor ); ?>;
 			</script>
 
 			<?php

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1279,7 +1279,7 @@ class CMB_wysiwyg extends CMB_Field {
 			<script>
 				if ( 'undefined' === typeof( cmb_wysiwyg_editors ) )
 					var cmb_wysiwyg_editors = {};
-				cmb_wysiwyg_editors.<?php echo esc_js( $field_id ); ?> = <?php echo json_encode( $editor ); ?>;
+				cmb_wysiwyg_editors.<?php echo esc_js( $field_id ); ?> = <?php echo wp_json_encode( $editor ); ?>;
 			</script>
 
 			<?php


### PR DESCRIPTION
Some genius *cough cough* added the wrong type of escaping to the WYSIWYG field, causing it to break when repeatable. Whoops. 

Huge proprs to @ocean90 for digging this up and finding the fix!

Resolves #381 

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [x] Added any new PHPUnit tests
 - [x] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install
