### PR TITLE
Remove call to error_log()

### DIFF
--- a/custom-meta-boxes.php
+++ b/custom-meta-boxes.php
@@ -34,8 +34,6 @@ if ( ! defined( 'CMB_URL' ) ) {
 	define( 'CMB_URL', plugins_url( '', __FILE__ ) );
 }
 
-error_log( CMB_PATH );
-
 /**
  * Include base, required files.
  */


### PR DESCRIPTION
The main plugin file calls error_log( CMB_PATH ); after defining its constants.

Resolves #405

*I have:*
 - [ ] Run WordPress VIP PHPCS check and code parses without errors
 - [ ] Added any new PHPUnit tests
 - [ ] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [ ] Tested feature/bugfix on single and multisite install

@mikeselander