### PR TITLE
Only attempt to call getimagesize() if the icon is local.

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -584,8 +584,12 @@ class CMB_File_Field extends CMB_Field {
 
 		if ( $this->get_value() ) {
 			$src = wp_mime_type_icon( $this->get_value() );
-			$size = getimagesize( str_replace( site_url(), ABSPATH, $src ) );
-			$icon_img = '<img src="' . $src . '" ' . $size[3] . ' />';
+			if ( strpos( $src, site_url() !== false ) ) {
+				$size = getimagesize( str_replace( site_url(), ABSPATH, $src ) );
+			} else {
+				$size = null;
+			}
+			$icon_img = '<img src="' . $src . '" ' . ( $size ? $size[3] : '' ) . ' />';
 		}
 
 		$data_type = ( ! empty( $this->args['library-type'] ) ? implode( ',', $this->args['library-type'] ) : null );


### PR DESCRIPTION
If it's not, or this perticular string replace doesn't work then we dont' want to be calling `getimagesize()` on remote images. Not having the size information really isn't a big deal so it's an ok compromise I think.