### PR TITLE
Add CMB_VERSION const.

### DIFF
--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -180,9 +180,9 @@ class CMB_Meta_Box {
 		$suffix = CMB_DEV ? '' : '.min';
 
 		if ( version_compare( get_bloginfo( 'version' ), '3.8', '>=' ) ) {
-			wp_enqueue_style( 'cmb-styles', trailingslashit( CMB_URL ) . "css/dist/cmb$suffix.css", CMB_VERSION );
+			wp_enqueue_style( 'cmb-styles', trailingslashit( CMB_URL ) . "css/dist/cmb$suffix.css", array(), CMB_VERSION );
 		} else {
-			wp_enqueue_style( 'cmb-styles', trailingslashit( CMB_URL ) . 'css/legacy.css', CMB_VERSION );
+			wp_enqueue_style( 'cmb-styles', trailingslashit( CMB_URL ) . 'css/legacy.css', array(), CMB_VERSION );
 		}
 
 		foreach ( $this->fields as $field ) {

--- a/class.cmb-meta-box.php
+++ b/class.cmb-meta-box.php
@@ -156,7 +156,7 @@ class CMB_Meta_Box {
 	 */
 	function enqueue_scripts() {
 
-		wp_enqueue_script( 'cmb-scripts', trailingslashit( CMB_URL ) . 'js/cmb.js', array( 'jquery' ) );
+		wp_enqueue_script( 'cmb-scripts', trailingslashit( CMB_URL ) . 'js/cmb.js', array( 'jquery' ), CMB_VERSION );
 
 		wp_localize_script( 'cmb-scripts', 'CMBData', array(
 			'strings' => array(
@@ -180,9 +180,9 @@ class CMB_Meta_Box {
 		$suffix = CMB_DEV ? '' : '.min';
 
 		if ( version_compare( get_bloginfo( 'version' ), '3.8', '>=' ) ) {
-			wp_enqueue_style( 'cmb-styles', trailingslashit( CMB_URL ) . "css/dist/cmb$suffix.css" );
+			wp_enqueue_style( 'cmb-styles', trailingslashit( CMB_URL ) . "css/dist/cmb$suffix.css", CMB_VERSION );
 		} else {
-			wp_enqueue_style( 'cmb-styles', trailingslashit( CMB_URL ) . 'css/legacy.css' );
+			wp_enqueue_style( 'cmb-styles', trailingslashit( CMB_URL ) . 'css/legacy.css', CMB_VERSION );
 		}
 
 		foreach ( $this->fields as $field ) {

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -676,7 +676,7 @@ class CMB_File_Field extends CMB_Field {
 		parent::enqueue_scripts();
 
 		wp_enqueue_media( array( 'post' => $post_ID ) );
-		wp_enqueue_script( 'cmb-file-upload', trailingslashit( CMB_URL ) . 'js/file-upload.js', array( 'jquery', 'cmb-scripts' ) );
+		wp_enqueue_script( 'cmb-file-upload', trailingslashit( CMB_URL ) . 'js/file-upload.js', array( 'jquery', 'cmb-scripts' ), CMB_VERSION );
 
 	}
 
@@ -967,7 +967,7 @@ class CMB_Date_Field extends CMB_Field {
 	public function enqueue_scripts() {
 		parent::enqueue_scripts();
 		wp_enqueue_style( 'cmb-jquery-ui', trailingslashit( CMB_URL ) . 'css/vendor/jquery-ui/jquery-ui.css', '1.10.3' );
-		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ) );
+		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ), CMB_VERSION );
 	}
 
 	/**
@@ -1006,7 +1006,7 @@ class CMB_Time_Field extends CMB_Field {
 		wp_enqueue_style( 'cmb-jquery-ui', trailingslashit( CMB_URL ) . 'css/vendor/jquery-ui/jquery-ui.css', '1.10.3' );
 
 		wp_enqueue_script( 'cmb-timepicker', trailingslashit( CMB_URL ) . 'js/jquery.timePicker.min.js', array( 'jquery', 'cmb-scripts' ) );
-		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ) );
+		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ), CMB_VERSION );
 	}
 
 	/**
@@ -1042,7 +1042,7 @@ class CMB_Date_Timestamp_Field extends CMB_Field {
 		wp_enqueue_style( 'cmb-jquery-ui', trailingslashit( CMB_URL ) . 'css/vendor/jquery-ui/jquery-ui.css', '1.10.3' );
 
 		wp_enqueue_script( 'cmb-timepicker', trailingslashit( CMB_URL ) . 'js/jquery.timePicker.min.js', array( 'jquery', 'cmb-scripts' ) );
-		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ) );
+		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ), CMB_VERSION );
 
 	}
 
@@ -1092,7 +1092,7 @@ class CMB_Datetime_Timestamp_Field extends CMB_Field {
 		wp_enqueue_style( 'cmb-jquery-ui', trailingslashit( CMB_URL ) . 'css/vendor/jquery-ui/jquery-ui.css', '1.10.3' );
 
 		wp_enqueue_script( 'cmb-timepicker', trailingslashit( CMB_URL ) . 'js/jquery.timePicker.min.js', array( 'jquery', 'cmb-scripts' ) );
-		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ) );
+		wp_enqueue_script( 'cmb-datetime', trailingslashit( CMB_URL ) . 'js/field.datetime.js', array( 'jquery', 'jquery-ui-core', 'jquery-ui-datepicker', 'cmb-scripts' ), CMB_VERSION );
 	}
 
 	/**
@@ -1196,7 +1196,7 @@ class CMB_Color_Picker extends CMB_Field {
 
 		parent::enqueue_scripts();
 
-		wp_enqueue_script( 'cmb-colorpicker', trailingslashit( CMB_URL ) . 'js/field.colorpicker.js', array( 'jquery', 'wp-color-picker', 'cmb-scripts' ) );
+		wp_enqueue_script( 'cmb-colorpicker', trailingslashit( CMB_URL ) . 'js/field.colorpicker.js', array( 'jquery', 'wp-color-picker', 'cmb-scripts' ), CMB_VERSION );
 		wp_enqueue_style( 'wp-color-picker' );
 	}
 
@@ -1350,7 +1350,7 @@ class CMB_wysiwyg extends CMB_Field {
 
 		parent::enqueue_scripts();
 
-		wp_enqueue_script( 'cmb-wysiwyg', trailingslashit( CMB_URL ) . 'js/field-wysiwyg.js', array( 'jquery', 'cmb-scripts' ) );
+		wp_enqueue_script( 'cmb-wysiwyg', trailingslashit( CMB_URL ) . 'js/field-wysiwyg.js', array( 'jquery', 'cmb-scripts' ), CMB_VERSION );
 	}
 
 	/**
@@ -1496,7 +1496,7 @@ class CMB_Select extends CMB_Field {
 		parent::enqueue_scripts();
 
 		wp_enqueue_script( 'select2', trailingslashit( CMB_URL ) . 'js/vendor/select2/select2.js', array( 'jquery' ) );
-		wp_enqueue_script( 'field-select', trailingslashit( CMB_URL ) . 'js/field.select.js', array( 'jquery', 'select2', 'cmb-scripts' ) );
+		wp_enqueue_script( 'field-select', trailingslashit( CMB_URL ) . 'js/field.select.js', array( 'jquery', 'select2', 'cmb-scripts' ), CMB_VERSION );
 	}
 
 	/**

--- a/custom-meta-boxes.php
+++ b/custom-meta-boxes.php
@@ -22,6 +22,8 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+define( 'CMB_VERSION', '1.0.3' );
+
 if ( ! defined( 'CMB_DEV' ) ) {
 	define( 'CMB_DEV', false );
 }

--- a/custom-meta-boxes.php
+++ b/custom-meta-boxes.php
@@ -22,7 +22,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-define( 'CMB_VERSION', '1.0.3' );
+if ( ! defined( 'CMB_VERSION' ) ) {
+	define( 'CMB_VERSION', '1.0.3' );
+}
 
 if ( ! defined( 'CMB_DEV' ) ) {
 	define( 'CMB_DEV', false );

--- a/fields/class-cmb-gmap-field.php
+++ b/fields/class-cmb-gmap-field.php
@@ -50,7 +50,7 @@ class CMB_Gmap_Field extends CMB_Field {
 
 		parent::enqueue_scripts();
 
-		wp_enqueue_script( 'cmb-google-maps-script', trailingslashit( CMB_URL ) . 'js/field-gmap.js', array( 'jquery' ) );
+		wp_enqueue_script( 'cmb-google-maps-script', trailingslashit( CMB_URL ) . 'js/field-gmap.js', array( 'jquery' ), CMB_VERSION );
 
 		// Check for our key with either a field argument or constant.
 		$key = '';


### PR DESCRIPTION
Let's add a constant to correctly bust any asset caching that occurs between library version bumps.

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [x] Tested feature/bugfix on single and multisite install

