### PR TITLE
Fixed method to fetch values

### DIFF
--- a/classes.fields.php
+++ b/classes.fields.php
@@ -1962,7 +1962,7 @@ class CMB_Group_Field extends CMB_Field {
 	public function html() {
 
 		$fields = &$this->get_fields();
-		$value  = $this->get_value();
+		$value  = $this->get_values();
 
 		// Reset all field values.
 		foreach ( $fields as $field ) {


### PR DESCRIPTION
You will notice that there is a foreach statement further down. the original method, ->get_value() returns just the string or value, and NOT an array. Changed to use ->get_values() instead. Works. Tested

Resolves #
Foreach error when retrieving existing values for meta boxes

*I have:*
 - [NO] Run WordPress VIP PHPCS check and code parses without errors
 - [NO] Added any new PHPUnit tests
 - [NO] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [YES] Tested feature/bugfix on single and multisite install

@mikeselander
