### PR TITLE
Enqueue and localize 'cmb-scripts' only once

### DIFF
--- a/class-cmb-meta-box.php
+++ b/class-cmb-meta-box.php
@@ -154,13 +154,16 @@ class CMB_Meta_Box {
 	 */
 	function enqueue_scripts() {
 
-		wp_enqueue_script( 'cmb-scripts', trailingslashit( CMB_URL ) . 'js/cmb.js', array( 'jquery' ), CMB_VERSION );
+		if ( ! wp_script_is( 'cmb-scripts' ) ) {
 
-		wp_localize_script( 'cmb-scripts', 'CMBData', array(
-			'strings' => array(
-				'confirmDeleteField' => esc_html__( 'Are you sure you want to delete this field?', 'cmb' ),
-			),
-		) );
+			wp_enqueue_script( 'cmb-scripts', trailingslashit( CMB_URL ) . 'js/cmb.js', array( 'jquery' ), CMB_VERSION );
+
+			wp_localize_script( 'cmb-scripts', 'CMBData', array(
+				'strings' => array(
+					'confirmDeleteField' => esc_html__( 'Are you sure you want to delete this field?', 'cmb' ),
+				),
+			) );
+		}
 
 		foreach ( $this->fields as $field ) {
 			$field->enqueue_scripts();


### PR DESCRIPTION
Checks if the `cmb-scripts` script is already enqueued before enqueueing and localizing it.
Prevents `CMBData` being output repeatedly for each registered meta box.

Resolves #411

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [ ] Added any new PHPUnit tests
 - [ ] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install

@mikeselander