### PR TITLE
Fix undefined index on meta cap

### DIFF
--- a/class-cmb-meta-box.php
+++ b/class-cmb-meta-box.php
@@ -104,7 +104,7 @@ class CMB_Meta_Box {
 
 			if ( class_exists( $class ) ) {
 				$field = new $class( $field['id'], $field['name'], (array) $values, $args );
-				if ( $field->is_displayed() ) {
+				if ( $field->is_displayed( $post_id ) ) {
 					$this->fields[] = $field;
 				}
 			}

--- a/fields/class-cmb-field.php
+++ b/fields/class-cmb-field.php
@@ -440,8 +440,8 @@ abstract class CMB_Field {
 	/**
 	 * Check whether the current field should or should not be displayed.
 	 */
-	public function is_displayed() {
-		return current_user_can( $this->args['capability'] );
+	public function is_displayed( $post_id ) {
+		return current_user_can( $this->args['capability'], $post_id );
 	}
 
 	/**


### PR DESCRIPTION
Fixes notice for undefined offset when edit_posts cap is checked without a post_id

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [x] Tested feature/bugfix on single and multisite install

@mikeselander
