### PR TITLE
Updated composer.json - Added Composer Installers "Type" Property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
       "custom-meta-boxes.php"
     ]
   },
+  "type": "wordpress-plugin",
   "require": {
     "composer/installers": "~1.0"
   }


### PR DESCRIPTION

## Added `"type": "wordpress-plugin"` to `composer.json` so that hosts may define a custom path for CMB installation

_Resolves N/A_

*I have:*
 - [ x ] Run WordPress VIP PHPCS check and code parses without errors
 - [ x ] Added any new PHPUnit tests
 - [ x ] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [ x ] Tested feature/bugfix on single and multisite install

--

A small change, but one that we have needed on a few occasions, and that is to specify where CMB is installed, especially when including it in the `inc` or `library` folder of another plugin.
