### PR TITLE
Add min/max attributes to number output

### DIFF
--- a/fields/class-cmb-number-field.php
+++ b/fields/class-cmb-number-field.php
@@ -32,9 +32,13 @@ class CMB_Number_Field extends CMB_Field {
 	 * Print out field HTML.
 	 */
 	public function html() {
+		$attrs = [];
+		$attrs[] = '' !== $this->args['step'] ? sprintf( 'step="%g"', $this->args['step'] ) : '';
+		$attrs[] = '' !== $this->args['min'] ? sprintf( 'min="%g"', $this->args['min'] ) : '';
+		$attrs[] = '' !== $this->args['max'] ? sprintf( 'max="%g"', $this->args['max'] ) : '';
 		?>
 
-		<input step="<?php echo esc_attr( $this->args['step'] ); ?>" <?php echo '' !== $this->args['min'] ? printf( 'min="%d"', $this->args['min'] ) : ''; ?> <?php echo '' !== $this->args['max'] ? printf( 'max="%d"', $this->args['max'] ) : ''; ?> type="number" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_number code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->get_value() ); ?>" />
+		<input <?php echo implode( ' ', $attrs ); ?> type="number" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_number code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->get_value() ); ?>" />
 
 		<?php
 	}

--- a/fields/class-cmb-number-field.php
+++ b/fields/class-cmb-number-field.php
@@ -22,6 +22,8 @@ class CMB_Number_Field extends CMB_Field {
 			parent::default_args(),
 			array(
 				'step' => '',
+				'min' => '',
+				'max' => '',
 			)
 		);
 	}
@@ -32,7 +34,7 @@ class CMB_Number_Field extends CMB_Field {
 	public function html() {
 		?>
 
-		<input step="<?php echo esc_attr( $this->args['step'] ); ?>" type="number" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_number code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->get_value() ); ?>" />
+		<input step="<?php echo esc_attr( $this->args['step'] ); ?>" <?php echo '' !== $this->args['min'] ? printf( 'min="%d"', $this->args['min'] ) : ''; ?> <?php echo '' !== $this->args['max'] ? printf( 'max="%d"', $this->args['max'] ) : ''; ?> type="number" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_number code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( $this->get_value() ); ?>" />
 
 		<?php
 	}

--- a/fields/class-cmb-number-field.php
+++ b/fields/class-cmb-number-field.php
@@ -22,8 +22,8 @@ class CMB_Number_Field extends CMB_Field {
 			parent::default_args(),
 			array(
 				'step' => '',
-				'min' => '',
-				'max' => '',
+				'min'  => '',
+				'max'  => '',
 			)
 		);
 	}

--- a/tests/testNumberField.php
+++ b/tests/testNumberField.php
@@ -45,15 +45,13 @@ class NumberFieldTestCase extends WP_UnitTestCase {
 	}
 
 	function testFieldOutput() {
-		$field        = new CMB_Number_Field( 'foo', 'Foo', array( 0.5 ), array( 'min' => 0.5, 'max' => 1 ) );
+		$field        = new CMB_Number_Field( 'foo', 'Foo', array( 0.5 ), array( 'min' => 0.4, 'max' => 1 ) );
 
 		if ( ! $this->post ) {
 			$this->markTestSkipped( 'Post not found' );
 		}
 
-		$this->expectOutputRegex( '/(type=\"number\".*?id=\"foo-cmb-field-0\".*?value=\"0.5\")/s' );
-		$this->expectOutputRegex( '/min="0.5"/s' );
-		$this->expectOutputRegex( '/max="1"/s' );
+		$this->expectOutputRegex( '/min="0.4".*max="1".*(type=\"number\".*?id=\"foo-cmb-field-0\".*?value=\"0.5\")/s' );
 
 		// Trigger output.
 		$field->html();

--- a/tests/testNumberField.php
+++ b/tests/testNumberField.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Tests for the number field type.
+ *
+ * @package WordPress
+ * @subpackage Custom Meta Boxes
+ */
+
+class NumberFieldTestCase extends WP_UnitTestCase {
+
+	function setUp() {
+		parent::setUp();
+
+		$args = array(
+			'post_author'  => 1,
+			'post_status'  => 'publish',
+			'post_content' => rand_str(),
+			'post_title'   => rand_str(),
+			'post_type'    => 'post',
+		);
+
+		$id = wp_insert_post( $args );
+
+		$this->post = get_post( $id );
+	}
+
+	function tearDown() {
+		wp_delete_post( $this->post->ID, true );
+		unset( $this->post );
+		parent::tearDown();
+	}
+
+	function testSaveValue() {
+		$value = array( 0.5 );
+		$field = new CMB_Number_Field( 'foo', 'Foo', $value, array( 'min' => 0, 'max' => 1 ) );
+
+		if ( ! $this->post ) {
+			$this->markTestSkipped( 'Post not found' );
+		}
+
+		$field->save( $this->post->ID, $value );
+
+		// Verify single value is properly saved.
+		$this->assertEquals( get_post_meta( $this->post->ID, 'foo', false ), $value );
+	}
+
+	function testFieldOutput() {
+		$field        = new CMB_Number_Field( 'foo', 'Foo', array( 0.5 ), array( 'min' => 0, 'max' => 1 ) );
+
+		if ( ! $this->post ) {
+			$this->markTestSkipped( 'Post not found' );
+		}
+
+		$this->expectOutputRegex( '/(type=\"number\".*?id=\"foo-cmb-field-0\".*?value=\"0.5\")/s' );
+		$this->expectOutputRegex( '/min="0"/s' );
+		$this->expectOutputRegex( '/max="1"/s' );
+
+		// Trigger output.
+		$field->html();
+	}
+}

--- a/tests/testNumberField.php
+++ b/tests/testNumberField.php
@@ -45,14 +45,14 @@ class NumberFieldTestCase extends WP_UnitTestCase {
 	}
 
 	function testFieldOutput() {
-		$field        = new CMB_Number_Field( 'foo', 'Foo', array( 0.5 ), array( 'min' => 0, 'max' => 1 ) );
+		$field        = new CMB_Number_Field( 'foo', 'Foo', array( 0.5 ), array( 'min' => 0.5, 'max' => 1 ) );
 
 		if ( ! $this->post ) {
 			$this->markTestSkipped( 'Post not found' );
 		}
 
 		$this->expectOutputRegex( '/(type=\"number\".*?id=\"foo-cmb-field-0\".*?value=\"0.5\")/s' );
-		$this->expectOutputRegex( '/min="0"/s' );
+		$this->expectOutputRegex( '/min="0.5"/s' );
 		$this->expectOutputRegex( '/max="1"/s' );
 
 		// Trigger output.


### PR DESCRIPTION
Adds support for min/max attributes for number outputs.

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [x] Added any new PHPUnit tests
 - [ ] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install

@mikeselander
