### PR TITLE
Use $this->get_value() in CMB_Textarea_Field

### DIFF
--- a/fields/class-cmb-textarea-field.php
+++ b/fields/class-cmb-textarea-field.php
@@ -21,7 +21,7 @@ class CMB_Textarea_Field extends CMB_Field {
 	public function html() {
 		?>
 
-		<textarea <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr(); ?> rows="<?php echo ! empty( $this->args['rows'] ) ? esc_attr( $this->args['rows'] ) : 4; ?>" <?php $this->name_attr(); ?>><?php echo esc_textarea( $this->value ); ?></textarea>
+		<textarea <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr(); ?> rows="<?php echo ! empty( $this->args['rows'] ) ? esc_attr( $this->args['rows'] ) : 4; ?>" <?php $this->name_attr(); ?>><?php echo esc_textarea( $this->get_value() ); ?></textarea>
 
 		<?php
 	}


### PR DESCRIPTION
Use `$this->get_value()` in stead of `$this->value` in CMB_Textarea_Field

Resolves #437

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [x] Added any new PHPUnit tests
 - [x] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install

@mikeselander
