### PR TITLE
Use site language when loading Google Maps API

### DIFF
--- a/fields/class-cmb-gmap-field.php
+++ b/fields/class-cmb-gmap-field.php
@@ -34,6 +34,7 @@ class CMB_Gmap_Field extends CMB_Field {
 				'string-marker-title'         => esc_html__( 'Drag to set the exact location', 'cmb' ),
 				'string-gmaps-api-not-loaded' => esc_html__( 'Google Maps API not loaded.', 'cmb' ),
 				'google_api_key'              => '',
+				'language'                    => explode( '_', get_locale() )[0],
 			)
 		);
 	}
@@ -68,6 +69,7 @@ class CMB_Gmap_Field extends CMB_Field {
 				'markerTitle'            => $this->args['string-marker-title'],
 				'googleMapsApiNotLoaded' => $this->args['string-gmaps-api-not-loaded'],
 			),
+			'language' => $this->args['language'],
 		) );
 
 	}

--- a/js/field-gmap.js
+++ b/js/field-gmap.js
@@ -100,6 +100,6 @@
 		CMB.addCallbackForClonedField( ['CMB_Gmap_Field'], CMBGmapsInit );
 	};
 
-	$.getScript( '//maps.google.com/maps/api/js?sensor=true&libraries=places&callback=CMB_CMAPS_INIT&key=' + CMBGmaps.key );
+	$.getScript( '//maps.google.com/maps/api/js?sensor=true&libraries=places&language=' + CMBGmaps.language +  '&callback=CMB_CMAPS_INIT&key=' + CMBGmaps.key );
 
 }(jQuery));


### PR DESCRIPTION
The Google Maps field always shows in english. This pull request uses `get_locale()` to pass along a language parameter when getting the API script.

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [ ] Added any new PHPUnit tests
 - [ ] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install

@mikeselander
