### PR TITLE
Remove passing-by-reference of get_values method

### DIFF
--- a/fields/class-cmb-checkbox-multi.php
+++ b/fields/class-cmb-checkbox-multi.php
@@ -110,7 +110,7 @@ class CMB_Checkbox_Multi extends CMB_Field {
 	 *
 	 * @return array
 	 */
-	public function &get_values() {
+	public function get_values() {
 
 		// We always want to fetch the existing (possibly empty) values if it's an existing object.
 		if ( ! $this->is_new_object() ) {

--- a/fields/class-cmb-field.php
+++ b/fields/class-cmb-field.php
@@ -360,7 +360,7 @@ abstract class CMB_Field {
 	 *
 	 * @return array
 	 */
-	public function &get_values() {
+	public function get_values() {
 		return $this->values;
 	}
 

--- a/fields/class-cmb-gmap-field.php
+++ b/fields/class-cmb-gmap-field.php
@@ -79,7 +79,7 @@ class CMB_Gmap_Field extends CMB_Field {
 	 *
 	 * @return array
 	 */
-	public function &get_values() {
+	public function get_values() {
 		return ( ! $this->args['repeatable'] ) ? array( $this->values ) : $this->values;
 	}
 

--- a/fields/class-cmb-group-field.php
+++ b/fields/class-cmb-group-field.php
@@ -163,7 +163,7 @@ class CMB_Group_Field extends CMB_Field {
 	 */
 	public function html() {
 
-		$fields = &$this->get_fields();
+		$fields = $this->get_fields();
 		$value  = $this->get_value();
 
 		// Reset all field values.
@@ -199,8 +199,8 @@ class CMB_Group_Field extends CMB_Field {
 	 */
 	public function parse_save_values() {
 
-		$fields = &$this->get_fields();
-		$values = &$this->get_values();
+		$fields = $this->get_fields();
+		$values = $this->get_values();
 
 		foreach ( $values as &$group_value ) {
 			foreach ( $group_value as $field_id => &$field_value ) {
@@ -224,6 +224,7 @@ class CMB_Group_Field extends CMB_Field {
 			}
 		}
 
+		$this->set_values( $values );
 	}
 
 	/**
@@ -241,7 +242,7 @@ class CMB_Group_Field extends CMB_Field {
 	 *
 	 * @return array
 	 */
-	public function &get_fields() {
+	public function get_fields() {
 		return $this->fields;
 	}
 
@@ -252,7 +253,7 @@ class CMB_Group_Field extends CMB_Field {
 	 */
 	public function set_values( array $values ) {
 
-		$fields       = &$this->get_fields();
+		$fields       = $this->get_fields();
 		$this->values = $values;
 
 		// Reset all field values.

--- a/tests/testField.php
+++ b/tests/testField.php
@@ -7,25 +7,20 @@ class FieldTestCase extends WP_UnitTestCase {
 	private $users = array();
 
 	function setUp() {
-
 		parent::setUp();
-
-		$args = array(
-			'post_author' => 1,
-			'post_status' => 'publish',
-			'post_content' => rand_str(),
-			'post_title' => rand_str(),
-			'post_type' => 'post',
-		);
-
-		$id = wp_insert_post( $args );
-
-		$this->post = get_post( $id );
 
 		// Setup some users to test our display logic.
 		$this->users['admin'] = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		$this->users['author'] = $this->factory->user->create( array( 'role' => 'author' ) );
 
+		// Setup a post for testing is_displayed.
+		$this->post = $this->factory->post->create_and_get( array(
+			'post_author'  => 1,
+			'post_status'  => 'publish',
+			'post_content' => rand_str(),
+			'post_title'   => rand_str(),
+			'post_type'    => 'post',
+		) );
 	}
 
 	function tearDown() {
@@ -236,17 +231,17 @@ class FieldTestCase extends WP_UnitTestCase {
 		wp_set_current_user( $this->users['admin'] );
 
 		// Test default value against default admin.
-		$this->assertTrue( $field->is_displayed() );
+		$this->assertTrue( $field->is_displayed( $this->post->ID ) );
 
 		// Re-setup the field with some capability logic in there.
 		$field = new CMB_Text_Field( 'foo', 'Title', array( 1 ), array( 'capability' => 'edit_others_posts' ) );
 
 		// Should still return true for admin.
-		$this->assertTrue( $field->is_displayed() );
+		$this->assertTrue( $field->is_displayed( $this->post->ID ) );
 
 		// Change to the author and test against our modified permission.
 		wp_set_current_user( $this->users['author'] );
 
-		$this->assertFalse( $field->is_displayed() );
+		$this->assertFalse( $field->is_displayed( $this->post->ID ) );
 	}
 }


### PR DESCRIPTION
We were passing the get_values method by reference in field classes. I do not understand why and can't find a good reason to keep it this way.

Resolves #420

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [ ] Added any new PHPUnit tests
 - [x] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install