### PR TITLE
Fix `is_displayed` Tests

### DIFF
--- a/fields/class-cmb-field.php
+++ b/fields/class-cmb-field.php
@@ -439,6 +439,8 @@ abstract class CMB_Field {
 
 	/**
 	 * Check whether the current field should or should not be displayed.
+	 *
+	 * @param int $post_id Post ID to check against.
 	 */
 	public function is_displayed( $post_id ) {
 		return current_user_can( $this->args['capability'], $post_id );

--- a/tests/testField.php
+++ b/tests/testField.php
@@ -7,25 +7,20 @@ class FieldTestCase extends WP_UnitTestCase {
 	private $users = array();
 
 	function setUp() {
-
 		parent::setUp();
-
-		$args = array(
-			'post_author' => 1,
-			'post_status' => 'publish',
-			'post_content' => rand_str(),
-			'post_title' => rand_str(),
-			'post_type' => 'post',
-		);
-
-		$id = wp_insert_post( $args );
-
-		$this->post = get_post( $id );
 
 		// Setup some users to test our display logic.
 		$this->users['admin'] = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		$this->users['author'] = $this->factory->user->create( array( 'role' => 'author' ) );
 
+		// Setup a post for testing is_displayed.
+		$this->post = $this->factory->post->create_and_get( array(
+			'post_author'  => 1,
+			'post_status'  => 'publish',
+			'post_content' => rand_str(),
+			'post_title'   => rand_str(),
+			'post_type'    => 'post',
+		) );
 	}
 
 	function tearDown() {
@@ -236,17 +231,17 @@ class FieldTestCase extends WP_UnitTestCase {
 		wp_set_current_user( $this->users['admin'] );
 
 		// Test default value against default admin.
-		$this->assertTrue( $field->is_displayed() );
+		$this->assertTrue( $field->is_displayed( $this->post->ID ) );
 
 		// Re-setup the field with some capability logic in there.
 		$field = new CMB_Text_Field( 'foo', 'Title', array( 1 ), array( 'capability' => 'edit_others_posts' ) );
 
 		// Should still return true for admin.
-		$this->assertTrue( $field->is_displayed() );
+		$this->assertTrue( $field->is_displayed( $this->post->ID ) );
 
 		// Change to the author and test against our modified permission.
 		wp_set_current_user( $this->users['author'] );
 
-		$this->assertFalse( $field->is_displayed() );
+		$this->assertFalse( $field->is_displayed( $this->post->ID ) );
 	}
 }


### PR DESCRIPTION
is_displayed test weren't being passed a post ID causing them to fail. Fixes this issue.

Resolves #

*I have:*
 - [ ] Run WordPress VIP PHPCS check and code parses without errors
 - [ ] Added any new PHPUnit tests
 - [ ] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [ ] Tested feature/bugfix on single and multisite install

@mikeselander
