### PR TITLE
Fix notice with array conversion.

### DIFF
--- a/fields/class-cmb-checkbox-multi.php
+++ b/fields/class-cmb-checkbox-multi.php
@@ -117,6 +117,6 @@ class CMB_Checkbox_Multi extends CMB_Field {
 			return $this->values;
 		}
 
-		return array_flip( $this->args['default'] );
+		return array_flip( (array) $this->args['default'] );
 	}
 }


### PR DESCRIPTION
When not explicitly passing a default value to the checkbox_multi field, the default is an empty string instead of an array which doesn't work with `array_flip`.

The solution is to cast the checkbox multi default value to an array.

*I have:*
 - [x] Run WordPress VIP PHPCS check and code parses without errors
 - [n/a] Added any new PHPUnit tests
 - [n/a] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [x] Tested feature/bugfix on single and multisite install
