### PR TITLE
Make URL field a url type

### DIFF
--- a/fields/class-cmb-url-field.php
+++ b/fields/class-cmb-url-field.php
@@ -18,7 +18,7 @@ class CMB_URL_Field extends CMB_Field {
 	public function html() {
 		?>
 
-		<input type="text" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_url code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( esc_url( $this->value ) ); ?>" />
+		<input type="url" <?php $this->id_attr(); ?> <?php $this->boolean_attr(); ?> <?php $this->class_attr( 'cmb_text_url code' ); ?> <?php $this->name_attr(); ?> value="<?php echo esc_attr( esc_url( $this->value ) ); ?>" />
 
 		<?php
 	}


### PR DESCRIPTION
Change URL Field to URL field type

Resolves #

*I have:*
 - [ ] Run WordPress VIP PHPCS check and code parses without errors
 - [ ] Added any new PHPUnit tests
 - [ ] Run PHPUnit and all tests are passing after adding any necessary new tests
 - [ ] Tested feature/bugfix on single and multisite install

@mikeselander
