### PR TITLE
Update default capability for fields.

### DIFF
--- a/fields/class-cmb-field.php
+++ b/fields/class-cmb-field.php
@@ -70,7 +70,7 @@ abstract class CMB_Field {
 			'class'               => '',
 			'data_delegate'       => null,
 			'save_callback'       => null,
-			'capability'          => 'edit_posts',
+			'capability'          => 'edit_post',
 			'string-repeat-field' => __( 'Add New', 'cmb' ),
 			'string-delete-field' => __( 'Remove', 'cmb' ),
 			'confirm_delete'      => true,


### PR DESCRIPTION
Change the **default** capability for any `CMB_Field` from [`edit_posts`](https://github.com/humanmade/Custom-Meta-Boxes/blob/664db7d8229dc024764f772892722780a4988145/fields/class-cmb-field.php#L73) to `edit_post` **meta** capability.
This has been discussed before with @mikeselander.

CMB uses the (default) capability for a [check with `current_user_can()`, supplying the current post ID](https://github.com/humanmade/Custom-Meta-Boxes/blob/664db7d8229dc024764f772892722780a4988145/fields/class-cmb-field.php#L432).
Using `edit_posts` (plural) is problematic for users that are some kind of a _sepcial editor_ for specific custom post types only, and thus don't have `edit_posts`.

Using the `edit_post` **meta** capability will result in all custom fields, by default, being accessible to users that can edit the current post—which makes sense, to me. The post ID is already passed along.